### PR TITLE
#45: fix font rendering in editor

### DIFF
--- a/src/AvaloniaVS/Views/AvaloniaDesignerHostView.xaml
+++ b/src/AvaloniaVS/Views/AvaloniaDesignerHostView.xaml
@@ -70,7 +70,9 @@
                 </DockPanel>
             </lc:SplitterContainer.Designer>
             <lc:SplitterContainer.Editor>
-                <lc:FocusableContentPresenter DataContext="{Binding DataContext, ElementName=Root}" Content="{Binding EditView}" />
+                <lc:FocusableContentPresenter TextOptions.TextFormattingMode="{Binding (TextOptions.TextFormattingMode), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type FrameworkElement}}}"
+                                              DataContext="{Binding DataContext, ElementName=Root}"
+                                              Content="{Binding EditView}" />
             </lc:SplitterContainer.Editor>
             <lc:SplitterContainer.ExtraPanel>
                 <StackPanel Orientation="Horizontal" DataContext="{Binding ElementName=Root, Path=DataContext}">


### PR DESCRIPTION
Fix #45.

Usually, `TextOptions.TextFormattingMode = Display` is inherited from some top-level Visual Studio container where it's set to `Display`. But in our case, it doesn't happen due to some reason, so the default value if `Ideal` takes precedence.

It seems that the default inheritance for `TextOptions.TextFormattingMode` doesn't work in our case because `SplitterContainer.Editor` is getting removed and reattached to the visual tree in the code.

So, we have to bring the inheritance back ourselves in that place.

After that fix, #45 is no more relevant, and I can see the same font rendering mode in both Visual Studio and AvaloniaVS' windows.