### PR TITLE
.NET Core template: save project on creation

### DIFF
--- a/src/Templates/AvaloniaCoreApplicationTemplate/AvaloniaCoreApplicationTemplate.vstemplate
+++ b/src/Templates/AvaloniaCoreApplicationTemplate/AvaloniaCoreApplicationTemplate.vstemplate
@@ -11,6 +11,7 @@
     <DefaultName>AvaloniaCoreApplication</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <CreateInPlace>true</CreateInPlace>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>
   <TemplateContent>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">


### PR DESCRIPTION
Fixes AvaloniaUI/Avalonia#1224
## Changes
- Added `<PromptForSaveOnCreation>true</PromptForSaveOnCreation>` to the .NET Core project template.