### PR TITLE
Fix Avalonia.Ide submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/external/Avalonia.Ide"]
 	path = src/external/Avalonia.Ide
-	url = git@github.com:AvaloniaUI/Avalonia.Ide.git
+	url = https://github.com/kekekeks/Avalonia.Ide


### PR DESCRIPTION
It was previously pointing to a non-existent submodule.