### PR TITLE
Some fixes to templates

### DIFF
--- a/AvaloniaVS/source.extension.vsixmanifest
+++ b/AvaloniaVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AvaloniaForVisualStudio" Version="0.8.0.0" Language="en-US" Publisher="Avalonia UI" />
+        <Identity Id="AvaloniaForVisualStudio" Version="0.8.0.1" Language="en-US" Publisher="Avalonia UI" />
         <DisplayName>Avalonia for Visual Studio</DisplayName>
         <Description xml:space="preserve">Previewer and templates for Avalonia applications and libraries.</Description>
     </Metadata>

--- a/templates/AvaloniaApplicationTemplate/ProjectTemplate.csproj
+++ b/templates/AvaloniaApplicationTemplate/ProjectTemplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">

--- a/templates/AvaloniaMvvmApplicationTemplate/Program.cs
+++ b/templates/AvaloniaMvvmApplicationTemplate/Program.cs
@@ -23,7 +23,12 @@ namespace $safeprojectname$
         // container, etc.
         private static void AppMain(Application app, string[] args)
         {
-            app.Run(new MainWindow());
+            var window = new MainWindow
+            {
+                DataContext = new MainWindowViewModel(),
+            };
+
+            app.Run(window);
         }
     }
 }

--- a/templates/AvaloniaMvvmApplicationTemplate/ProjectTemplate.csproj
+++ b/templates/AvaloniaMvvmApplicationTemplate/ProjectTemplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />


### PR DESCRIPTION
The 0.8.0.0 release had a couple of problems in its templates:

- Was targeting `netcoreapp2.0` which is EOL. Target `netcoreapp2.1` instead which is a LTS
- The MVVM application template didn't create the `MainWindowViewModel` at runtime