### PR TITLE
Fixed data binding issue in MVVM template

### DIFF
--- a/templates/AvaloniaMvvmApplicationTemplate/Views/MainWindow.xaml
+++ b/templates/AvaloniaMvvmApplicationTemplate/Views/MainWindow.xaml
@@ -8,9 +8,9 @@
         Icon="/Assets/avalonia-logo.ico"
         Title="$safeprojectname$">
 
-    <Design.DataContext>
+    <Window.DataContext>
         <vm:MainWindowViewModel/>
-    </Design.DataContext>
+    </Window.DataContext>
 
     <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 


### PR DESCRIPTION
Use Window.DataContext instead of Design.DataContext for proper data binding.