### PR TITLE
Fix error tooltips and no solution loaded

### DIFF
--- a/AvaloniaVS/IntelliSense/XamlErrorTagger.cs
+++ b/AvaloniaVS/IntelliSense/XamlErrorTagger.cs
@@ -85,7 +85,7 @@ namespace AvaloniaVS.IntelliSense
                 var span = _navigator.GetSpanOfFirstChild(startSpan);
                 var tag = new ErrorTag(PredefinedErrorTypeNames.CompilerError, _error.Message);
 
-                if (spans.OverlapsWith(span))
+                if (spans.IntersectsWith(span))
                 {
                     _tagSpan = new TagSpan<IErrorTag>(span, tag);
                     return new[] { _tagSpan };

--- a/AvaloniaVS/IntelliSense/XamlErrorTagger.cs
+++ b/AvaloniaVS/IntelliSense/XamlErrorTagger.cs
@@ -24,6 +24,7 @@ namespace AvaloniaVS.IntelliSense
         private readonly string _path;
         private PreviewerProcess _process;
         private ExceptionDetails _error;
+        private ITagSpan<IErrorTag> _tagSpan;
         private ITableDataSink _sink;
 
         public XamlErrorTagger(
@@ -86,7 +87,8 @@ namespace AvaloniaVS.IntelliSense
 
                 if (spans.OverlapsWith(span))
                 {
-                    return new[] { new TagSpan<IErrorTag>(span, tag) };
+                    _tagSpan = new TagSpan<IErrorTag>(span, tag);
+                    return new[] { _tagSpan };
                 }
             }
 
@@ -107,7 +109,11 @@ namespace AvaloniaVS.IntelliSense
 
         private void HandleErrorChanged(object sender, EventArgs e)
         {
-            RaiseTagsChanged(_error);
+            if (_tagSpan != null)
+            {
+                TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(_tagSpan.Span));
+                _tagSpan = null;
+            }
 
             _error = _process.Error;
 

--- a/AvaloniaVS/IntelliSense/XamlErrorTaggerProvider.cs
+++ b/AvaloniaVS/IntelliSense/XamlErrorTaggerProvider.cs
@@ -10,7 +10,7 @@ namespace AvaloniaVS.IntelliSense
 {
     [Export(typeof(ITaggerProvider))]
     [ContentType("xml")]
-    [TagType(typeof(ErrorTag))]
+    [TagType(typeof(IErrorTag))]
     internal class XamlErrorTaggerProvider : ITaggerProvider
     {
         private readonly ITextStructureNavigatorSelectorService _navigatorProvider;

--- a/AvaloniaVS/Services/SolutionService.cs
+++ b/AvaloniaVS/Services/SolutionService.cs
@@ -48,7 +48,7 @@ namespace AvaloniaVS.Services
 
             var result = new Dictionary<Project, ProjectInfo>();
             var uninitialized = new Dictionary<VSProject, ProjectInfo>();
-            var startupProjects = ((Array)_dte.Solution.SolutionBuild.StartupProjects).Cast<string>().ToList();
+            var startupProjects = ((Array)_dte.Solution.SolutionBuild.StartupProjects)?.Cast<string>().ToList();
 
             foreach (var project in FlattenProjects(_dte.Solution))
             {
@@ -56,7 +56,7 @@ namespace AvaloniaVS.Services
                 {
                     var projectInfo = new ProjectInfo
                     {
-                        IsStartupProject = startupProjects.Contains(project.UniqueName),
+                        IsStartupProject = startupProjects?.Contains(project.UniqueName) ?? false,
                         Name = project.Name,
                         Project = project,
                         ProjectReferences = GetProjectReferences(vsProject),

--- a/AvaloniaVS/source.extension.vsixmanifest
+++ b/AvaloniaVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AvaloniaForVisualStudio" Version="0.8.0.1" Language="en-US" Publisher="Avalonia UI" />
+        <Identity Id="AvaloniaForVisualStudio" Version="0.8.0.2" Language="en-US" Publisher="Avalonia UI" />
         <DisplayName>Avalonia for Visual Studio</DisplayName>
         <Description xml:space="preserve">Previewer and templates for Avalonia applications and libraries.</Description>
     </Metadata>


### PR DESCRIPTION
- Better handle the case when the user doesn't have a solution loaded. This can happen e.g. when the user has a folder open rather than a solution
- Correctly remove out of date error tags
- Fix error tooltips not appearing
- Update version to 0.8.0.2