### PR TITLE
Add entry to "Open With..." menu.

### DIFF
--- a/AvaloniaVS/AvaloniaPackage.cs
+++ b/AvaloniaVS/AvaloniaPackage.cs
@@ -15,10 +15,25 @@ namespace AvaloniaVS
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_string, PackageAutoLoadFlags.BackgroundLoad)]
-    [ProvideEditorExtension(typeof(EditorFactory), ".paml", 100, NameResourceID = 113, DefaultName = "Avalonia Xaml Editor")]
+    [ProvideEditorExtension(
+        typeof(EditorFactory),
+        ".paml",
+        100,
+        NameResourceID = 113,
+        EditorFactoryNotify = true,
+        ProjectGuid = VSConstants.UICONTEXT.CSharpProject_string,
+        DefaultName = Name)]
+    [ProvideEditorExtension(
+        typeof(EditorFactory),
+        ".xaml",
+        0x40,
+        NameResourceID = 113,
+        EditorFactoryNotify = true,
+        ProjectGuid = VSConstants.UICONTEXT.CSharpProject_string,
+        DefaultName = Name)]
     [ProvideEditorFactory(typeof(EditorFactory), 113, TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
     [ProvideEditorLogicalView(typeof(EditorFactory), LogicalViewID.Designer)]
-    [ProvideXmlEditorChooserDesignerView("Avalonia",
+    [ProvideXmlEditorChooserDesignerView(Name,
         "xaml",
         LogicalViewID.Designer,
         10000,
@@ -31,6 +46,7 @@ namespace AvaloniaVS
     internal sealed class AvaloniaPackage : AsyncPackage
     {
         public const string PackageGuidString = "865ba8d5-1180-4bf8-8821-345f72a4cb79";
+        public const string Name = "Avalonia Xaml Editor";
 
         public static SolutionService SolutionService { get; private set; }
 

--- a/AvaloniaVS/VSPackage.resx
+++ b/AvaloniaVS/VSPackage.resx
@@ -134,6 +134,9 @@
   <data name="112" xml:space="preserve">
     <value>AvaloniaPackage Visual Studio Extension Detailed Info</value>
   </data>
+  <data name="113" xml:space="preserve">
+    <value>Avalonia XAML Editor</value>
+  </data>
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\AvaloniaPackage.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>


### PR DESCRIPTION
Workaround for #95: VS doesn't recognise Avalonia XAML in certain situations. Add an "Avalonia XAML Editor" entry to VS' `Open With...` menu to force VS to open using our entension.

Fixes #95.

Co-Authored-By: Andrey Kunchev <donandren@users.noreply.github.com>

cc: @donandren - this is ported from your PR #107 