### PR TITLE
A couple of fixes to intellisense

### DIFF
--- a/AvaloniaVS/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS/IntelliSense/XamlCompletionCommandHandler.cs
@@ -138,6 +138,7 @@ namespace AvaloniaVS.IntelliSense
                     if (_session.SelectedCompletionSet.SelectionStatus.IsSelected)
                     {
                         var selected = _session.SelectedCompletionSet.SelectionStatus.Completion as XamlCompletion;
+                        var skip = !char.IsWhiteSpace(c);
 
                         _session.Commit();
 
@@ -164,8 +165,7 @@ namespace AvaloniaVS.IntelliSense
                             TriggerCompletion();
                         }
 
-                        // Don't add the character to the buffer.
-                        return true;
+                        return skip;
                     }
                     else
                     {


### PR DESCRIPTION
- Harden the code which gets the error tags in `XamlErrorTagger`: it was attempting to get spans for positions in the text buffer that no longer exist. Fixes #112 
- Add whitespace completion chars to buffer. Fixes #109 