### PR TITLE
Enable quick find in editor.

### DIFF
--- a/AvaloniaVS/AvaloniaVS.csproj
+++ b/AvaloniaVS/AvaloniaVS.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Models\ProjectInfo.cs" />
     <Compile Include="Models\ProjectOutputInfo.cs" />
     <Compile Include="Models\XamlBufferMetadata.cs" />
+    <Compile Include="Services\IVsFindTarget3.cs" />
     <Compile Include="Services\OutputPaneEventSink.cs" />
     <Compile Include="Services\SolutionService.cs" />
     <Compile Include="Services\Throttle.cs" />

--- a/AvaloniaVS/Services/IVsFindTarget3.cs
+++ b/AvaloniaVS/Services/IVsFindTarget3.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace AvaloniaVS.Services
+{
+    [ComImport]
+    [Guid("A2F0D62B-D0DD-4C59-AAB8-79CD20785451")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IVsFindTarget3
+    {
+        [PreserveSig]
+        int get_IsNewUISupported();
+
+        [PreserveSig]
+        int NotifyShowingNewUI();
+    }
+}

--- a/AvaloniaVS/Views/EditorHostPane.cs
+++ b/AvaloniaVS/Views/EditorHostPane.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.InteropServices;
+using AvaloniaVS.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
@@ -19,6 +21,7 @@ namespace AvaloniaVS.Views
         IOleCommandTarget,
         IVsFindTarget,
         IVsFindTarget2,
+        IVsFindTarget3,
         IVsDropdownBarManager,
         IVsUserData,
         IVsHasRelatedSaveItems,
@@ -115,6 +118,8 @@ namespace AvaloniaVS.Views
         int IVsFindTarget.NotifyFindTarget(uint notification) => ((IVsFindTarget)_editorWindow).NotifyFindTarget(notification);
         int IVsFindTarget.MarkSpan(TextSpan[] pts) => ((IVsFindTarget)_editorWindow).MarkSpan(pts);
         int IVsFindTarget2.NavigateTo2(IVsTextSpanSet pSpans, TextSelMode iSelMode) => ((IVsFindTarget2)_editorWindow).NavigateTo2(pSpans, iSelMode);
+        int IVsFindTarget3.get_IsNewUISupported() => 0;
+        int IVsFindTarget3.NotifyShowingNewUI() => 0;
         int IVsDropdownBarManager.AddDropdownBar(int cCombos, IVsDropdownBarClient pClient) => ((IVsDropdownBarManager)_editorWindow).AddDropdownBar(cCombos, pClient);
         int IVsDropdownBarManager.GetDropdownBar(out IVsDropdownBar ppDropdownBar) => ((IVsDropdownBarManager)_editorWindow).GetDropdownBar(out ppDropdownBar);
         int IVsDropdownBarManager.RemoveDropdownBar() => ((IVsDropdownBarManager)_editorWindow).RemoveDropdownBar();


### PR DESCRIPTION
Previously pressing Ctrl+F in the avalonia xaml editor would open the Find dialog instead of the Quick Find dialog. Fixed this by implementing an internal VS interface. Is there a better way to do this?

![image](https://user-images.githubusercontent.com/1775141/69802982-2422ec80-11db-11ea-9f8a-38791f87af46.png)

Fixes #108 