### PR TITLE
Correctly handle spacebar completion.

### DIFF
--- a/AvaloniaVS/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS/IntelliSense/XamlCompletionCommandHandler.cs
@@ -138,7 +138,10 @@ namespace AvaloniaVS.IntelliSense
                     if (_session.SelectedCompletionSet.SelectionStatus.IsSelected)
                     {
                         var selected = _session.SelectedCompletionSet.SelectionStatus.Completion as XamlCompletion;
-                        var skip = !char.IsWhiteSpace(c);
+
+                        // If the spacebar is used to complete then it should be entered into the
+                        // buffer, all other chars should be swallowed.
+                        var skip = c != ' ';
 
                         _session.Commit();
 


### PR DESCRIPTION
Previously we were passing through all whitespace, but this includes characters such as linefeed and carriage return, which was not correct.