### PR TITLE
Add optional shadow copy assemblies for designer

### DIFF
--- a/AvaloniaVS/Services/AvaloniaVSSettings.cs
+++ b/AvaloniaVS/Services/AvaloniaVSSettings.cs
@@ -20,6 +20,8 @@ namespace AvaloniaVS.Services
         private Orientation _designerSplitOrientation;
         private AvaloniaDesignerView _designerView = AvaloniaDesignerView.Split;
         private LogEventLevel _minimumLogVerbosity = LogEventLevel.Information;
+        private bool _useTempDir = false;
+        private string _tempDirPath = "dttmp";
 
         [ImportingConstructor]
         public AvaloniaVSSettings(SVsServiceProvider vsServiceProvider)
@@ -29,7 +31,7 @@ namespace AvaloniaVS.Services
             Load();
         }
 
-        public Orientation DesignerSplitOrientation 
+        public Orientation DesignerSplitOrientation
         {
             get => _designerSplitOrientation;
             set
@@ -68,6 +70,32 @@ namespace AvaloniaVS.Services
             }
         }
 
+        public bool UseTempDir
+        {
+            get => _useTempDir;
+            set
+            {
+                if (_useTempDir != value)
+                {
+                    _useTempDir = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string TempDirPath
+        {
+            get => _tempDirPath;
+            set
+            {
+                if (_tempDirPath != value)
+                {
+                    _tempDirPath = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         public void Load()
@@ -86,6 +114,14 @@ namespace AvaloniaVS.Services
                     SettingsKey,
                     nameof(MinimumLogVerbosity),
                     (int)LogEventLevel.Information);
+                UseTempDir = _settings.GetBoolean(
+                    SettingsKey,
+                    nameof(UseTempDir),
+                    false);
+                TempDirPath = _settings.GetString(
+                    SettingsKey,
+                    nameof(TempDirPath),
+                    "dttmp");
             }
             catch (Exception ex)
             {
@@ -105,6 +141,8 @@ namespace AvaloniaVS.Services
                 _settings.SetInt32(SettingsKey, nameof(DesignerSplitOrientation), (int)DesignerSplitOrientation);
                 _settings.SetInt32(SettingsKey, nameof(DesignerView), (int)DesignerView);
                 _settings.SetInt32(SettingsKey, nameof(MinimumLogVerbosity), (int)MinimumLogVerbosity);
+                _settings.SetBoolean(SettingsKey, nameof(UseTempDir), UseTempDir);
+                _settings.SetString(SettingsKey, nameof(TempDirPath), TempDirPath);
             }
             catch (Exception ex)
             {

--- a/AvaloniaVS/Services/IAvaloniaVSSettings.cs
+++ b/AvaloniaVS/Services/IAvaloniaVSSettings.cs
@@ -10,6 +10,8 @@ namespace AvaloniaVS.Services
         Orientation DesignerSplitOrientation { get; set; }
         AvaloniaDesignerView DesignerView { get; set; }
         LogEventLevel MinimumLogVerbosity { get; set; }
+        bool UseTempDir { get; set; }
+        string TempDirPath { get; set; }
         void Save();
         void Load();
     }

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -203,6 +203,8 @@ namespace AvaloniaVS.Views
         /// </summary>
         public void Dispose()
         {
+            var alreadyDisposed = _disposed;
+
             _disposed = true;
 
             if (_editor?.TextView.TextBuffer is ITextBuffer2 oldBuffer)
@@ -215,11 +217,19 @@ namespace AvaloniaVS.Views
                 _editor.Close();
             }
 
+            var assemblyPath = SelectedTarget?.XamlAssembly;
+            var executablePath = SelectedTarget?.ExecutableAssembly;
+
             Process.FrameReceived -= FrameReceived;
 
             _throttle.Dispose();
             previewer.Dispose();
             Process.Dispose();
+
+            if (!alreadyDisposed && assemblyPath != null && executablePath != null)
+            {
+                _ = Task.Delay(100).ContinueWith(t => TryCleanDesignTempData(executablePath, assemblyPath));
+            }
         }
 
         protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
@@ -361,6 +371,13 @@ namespace AvaloniaVS.Views
 
             if (assemblyPath != null && executablePath != null && hostAppPath != null)
             {
+                var d = TryPrepareDesignTempData(executablePath, assemblyPath);
+
+                if (!d.Equals(default((string, string))))
+                {
+                    assemblyPath = d.assemblyPath;
+                    executablePath = d.executablePath;
+                }
 
                 RebuildMetadata(assemblyPath, executablePath);
 
@@ -426,6 +443,106 @@ namespace AvaloniaVS.Views
                 {
                     CreateCompletionMetadataAsync(executablePath, metadata).FireAndForget();
                 }
+            }
+        }
+
+        static private (string executableDir, string assemblyDir) GetDesignTempDirs(string executablePath, string assemblyPath)
+        {
+            //let's try use very short folder names as limit for directory path is 248 chars
+            var designerTempDir = Path.Combine(Directory.GetParent(Path.GetDirectoryName(executablePath)).FullName, "dttmp");
+
+            var executableDirDesigner = $"{designerTempDir}_exe";
+            var assemblyDirDesigner = $"{designerTempDir}_asm";
+
+            return (executableDirDesigner, assemblyDirDesigner);
+        }
+
+        private (string executablePath, string assemblyPath) TryPrepareDesignTempData(string executablePath, string assemblyPath)
+        {
+            try
+            {
+                void CopyFile(string src, string dst)
+                {
+                    var srcFile = new FileInfo(src);
+                    var dstFile = new FileInfo(dst);
+
+                    if (!Directory.Exists(dstFile.DirectoryName))
+                        Directory.CreateDirectory(dstFile.DirectoryName);
+
+                    if (srcFile.LastWriteTime > dstFile.LastWriteTime || !dstFile.Exists)
+                        File.Copy(srcFile.FullName, dstFile.FullName, true);
+                }
+
+                void CopyFolder(string src, string dst, string mask = "*.*", bool recursive = false)
+                {
+                    var opt = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+
+                    foreach (var sourceFile in Directory.GetFiles(src, mask, opt))
+                    {
+                        CopyFile(sourceFile, $"{dst}{sourceFile.Replace(src, "")}");
+                    }
+                }
+
+                var executableDir = Path.GetDirectoryName(executablePath);
+                var assemblyDir = Path.GetDirectoryName(assemblyPath);
+
+                var tmpDirs = GetDesignTempDirs(executablePath, assemblyPath);
+
+                if (!tmpDirs.Equals(default((string, string))))
+                {
+                    var executableDirDesigner = tmpDirs.executableDir;
+                    var assemblyDirDesigner = tmpDirs.assemblyDir;
+
+                    CopyFolder(executableDir, executableDirDesigner, recursive: true);
+                    CopyFile(assemblyPath, Path.Combine(tmpDirs.assemblyDir, Path.GetFileName(assemblyPath)));
+
+                    Log.Logger.Verbose("Copied assemblies to temp folders:{ExecutableDirDesigner},{AssemblyDirDesigner}", executableDirDesigner, assemblyDirDesigner);
+
+                    var executablePathDesign = Path.Combine(executableDirDesigner, Path.GetFileName(executablePath));
+                    var assemblyPathDesign = Path.Combine(assemblyDirDesigner, Path.GetFileName(assemblyPath));
+
+                    Log.Logger.Verbose("Finished AvaloniaDesigner.TryPrepareDesignTempFolder()");
+
+                    return (executablePathDesign, assemblyPathDesign);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error(ex, "AvaloniaDesigner.TryPrepareDesignTempData() failed!");
+                ShowError("Prepare Design Time", $"Prepare Design Time Preview and Completion Failed:{ex.Message}");
+            }
+
+            return default((string, string));
+        }
+
+        static private void TryCleanDesignTempData(string executablePath, string assemblyPath)
+        {
+            try
+            {
+                var tmpDirs = GetDesignTempDirs(executablePath, assemblyPath);
+
+                if (tmpDirs.Equals(default((string, string))))
+                    return;
+
+                void deletefile(string path)
+                {
+                    Log.Information("Cleaning temp file {Path}", path);
+                    File.Delete(path);
+                }
+
+                void cleandir(string path)
+                {
+                    Log.Information("Cleaning temp folder {Path}", path);
+                    Directory.Delete(path, true);
+                }
+
+                deletefile(Path.Combine(tmpDirs.assemblyDir, Path.GetFileName(assemblyPath)));
+
+                cleandir(tmpDirs.executableDir);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Warning(ex, "AvaloniaDesigner.TryCleanDesignTempData() failed!");
             }
         }
 

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -154,6 +154,8 @@ namespace AvaloniaVS.Views
             set => SetValue(ViewProperty, value);
         }
 
+        public string DesignerTempPath { get; set; }
+
         /// <summary>
         /// Starts the designer.
         /// </summary>
@@ -446,12 +448,15 @@ namespace AvaloniaVS.Views
             }
         }
 
-        static private (string executableDir, string assemblyDir) GetDesignTempDirs(string executablePath, string assemblyPath)
+        private (string executableDir, string assemblyDir) GetDesignTempDirs(string executablePath, string assemblyPath)
         {
-            //let's try use very short folder names as limit for directory path is 248 chars
-            var designerTempDir = Path.Combine(Directory.GetParent(Path.GetDirectoryName(executablePath)).FullName, "dttmp");
+            if (string.IsNullOrEmpty(DesignerTempPath))
+                return default((string, string));
 
-            var executableDirDesigner = $"{designerTempDir}_exe";
+            //let's try use very short folder names as limit for directory path is 248 chars
+            var designerTempDir = Path.Combine(Directory.GetParent(Path.GetDirectoryName(executablePath)).FullName, DesignerTempPath);
+
+            var executableDirDesigner = $"{designerTempDir}";
             var assemblyDirDesigner = $"{designerTempDir}_asm";
 
             return (executableDirDesigner, assemblyDirDesigner);
@@ -515,7 +520,7 @@ namespace AvaloniaVS.Views
             return default((string, string));
         }
 
-        static private void TryCleanDesignTempData(string executablePath, string assemblyPath)
+        private void TryCleanDesignTempData(string executablePath, string assemblyPath)
         {
             try
             {

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -453,7 +453,6 @@ namespace AvaloniaVS.Views
             if (string.IsNullOrEmpty(DesignerTempPath))
                 return default((string, string));
 
-            //let's try use very short folder names as limit for directory path is 248 chars
             var designerTempDir = Path.Combine(Directory.GetParent(Path.GetDirectoryName(executablePath)).FullName, DesignerTempPath);
 
             var executableDirDesigner = $"{designerTempDir}";

--- a/AvaloniaVS/Views/DesignerPane.cs
+++ b/AvaloniaVS/Views/DesignerPane.cs
@@ -74,6 +74,7 @@ namespace AvaloniaVS.Views
             xamlEditorView.IsPaused = _isPaused;
             xamlEditorView.SplitOrientation = settings.DesignerSplitOrientation;
             xamlEditorView.View = settings.DesignerView;
+            xamlEditorView.DesignerTempPath = settings.UseTempDir ? settings.TempDirPath : null;
             xamlEditorView.Start(_project, _xamlPath, _editorHost);
             _content = xamlEditorView;
 

--- a/AvaloniaVS/Views/OptionsView.xaml
+++ b/AvaloniaVS/Views/OptionsView.xaml
@@ -19,9 +19,13 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="10" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="10" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="150" />
+            <ColumnDefinition Width="200" />
             <ColumnDefinition Width="20" />
             <ColumnDefinition Width="180"/>
         </Grid.ColumnDefinitions>
@@ -40,5 +44,17 @@
         <ComboBox Grid.Column="2" Grid.Row="4" VerticalAlignment="Center"
                   ItemsSource="{Binding Source={x:Type serilog:LogEventLevel}, Converter={StaticResource EnumValues}}"
                   SelectedItem="{Binding MinimumLogVerbosity, Mode=TwoWay}"/>
+
+        <CheckBox x:Name="chkCopyOutput" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" IsChecked="{Binding UseTempDir, Mode=TwoWay}">
+            <StackPanel>
+                <TextBlock Text="Shadow copy application output to temp folder for designer" TextWrapping="Wrap" />
+                <TextBlock Text="(helps with lock of build output)" />
+            </StackPanel>
+        </CheckBox>
+
+        <TextBlock Grid.Row="8" IsEnabled="{Binding UseTempDir}" Text="Designer Temp Folder Path
+                   (Relative to $(OutputPath) or absolute)" TextWrapping="Wrap"/>
+
+        <TextBox IsEnabled="{Binding UseTempDir}" Text="{Binding TempDirPath, Mode=TwoWay}" Grid.Row="8" Grid.Column="2" VerticalAlignment="Top" MinHeight="20" />
     </Grid>
 </UserControl>

--- a/AvaloniaVS/Views/OptionsView.xaml
+++ b/AvaloniaVS/Views/OptionsView.xaml
@@ -53,7 +53,7 @@
         </CheckBox>
 
         <TextBlock Grid.Row="8" IsEnabled="{Binding UseTempDir}" Text="Designer Temp Folder Path
-                   (Relative to $(OutputPath) or absolute)" TextWrapping="Wrap"/>
+                   (Relative to $(OutputPath))" TextWrapping="Wrap"/>
 
         <TextBox IsEnabled="{Binding UseTempDir}" Text="{Binding TempDirPath, Mode=TwoWay}" Grid.Row="8" Grid.Column="2" VerticalAlignment="Top" MinHeight="20" />
     </Grid>


### PR DESCRIPTION
added  a way to prevent lock of build output (which tend to happends very very often after 10-15 mins work with the extension).

The shadow copy option is configurable from the avalonia extension settings and be default is **off!**
The temp folder to copy application output for the designer run is also configurable.

When option enabled it just copy target application output to a configured temp folder and launches the app in a design mode.

extracted implementation from #107 with some improvements
Fixes: #54 

Note: this solution have been tested by me for several months and once i've started using this solution i didn't expirienced any lock of build output because of avalonia designer