### PR TITLE
Change GridSplitter style to look more like the WPF designer's splitter

### DIFF
--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml
@@ -108,8 +108,9 @@
             <GridSplitter x:Name="splitter"
                           Grid.Row="1"
                           Grid.Column="1"
-                          Height="5"
-                          HorizontalAlignment="Stretch"/>
+                          Height="20"
+                          HorizontalAlignment="Stretch"
+                          Background="{DynamicResource VsBrush.PanelSeparator}"/>
 
             <Decorator Grid.Row="2" Grid.Column="0" Name="editorHost"/>
         </Grid>

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml
@@ -108,7 +108,7 @@
             <GridSplitter x:Name="splitter"
                           Grid.Row="1"
                           Grid.Column="1"
-                          Height="20"
+                          Height="5"
                           HorizontalAlignment="Stretch"
                           Background="{DynamicResource VsBrush.PanelSeparator}"/>
 

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -519,7 +519,7 @@ namespace AvaloniaVS.Views
                     mainGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                     mainGrid.RowDefinitions.Add(codeRow);
                     mainGrid.ColumnDefinitions.Clear();
-                    splitter.Height = 20;
+                    splitter.Height = 5;
                     splitter.Width = double.NaN;
                 }
             }
@@ -532,7 +532,7 @@ namespace AvaloniaVS.Views
                     mainGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
                     mainGrid.ColumnDefinitions.Add(_codeCol);
                     mainGrid.RowDefinitions.Clear();
-                    splitter.Width = 20;
+                    splitter.Width = 5;
                     splitter.Height = double.NaN;
                 }
             }

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -519,7 +519,7 @@ namespace AvaloniaVS.Views
                     mainGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                     mainGrid.RowDefinitions.Add(codeRow);
                     mainGrid.ColumnDefinitions.Clear();
-                    splitter.Height = 5;
+                    splitter.Height = 20;
                     splitter.Width = double.NaN;
                 }
             }
@@ -532,7 +532,7 @@ namespace AvaloniaVS.Views
                     mainGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
                     mainGrid.ColumnDefinitions.Add(_codeCol);
                     mainGrid.RowDefinitions.Clear();
-                    splitter.Width = 5;
+                    splitter.Width = 20;
                     splitter.Height = double.NaN;
                 }
             }


### PR DESCRIPTION
The color is identical to the WPF designer's when using the Dark or Light theme.
It looks like they use a hard-coded value for the Blue theme, or maybe I just couldn't find the right color key. So when using the Blue theme it looks a bit darker than the WPF splitter. The same is true for the blue contrast theme.

I also made the splitter wider (just like in the WPF designer) because the smaller one was easier to overlook (user might not be aware that he can move it) and it's easier to grab. But I can revert that if wanted.