### PR TITLE
Use correct foreground color brush.

### DIFF
--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml
@@ -13,6 +13,7 @@
              mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800"
              Name="root"
              Background="{DynamicResource VsBrush.ToolWindowBackground}"
+             Foreground="{DynamicResource VsBrush.WindowText}"
              theming:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
 
     <UserControl.Resources>


### PR DESCRIPTION
So that text shows up correctly on dark themes.