### PR TITLE
Add event completion

### DIFF
--- a/AvaloniaVS/IntelliSense/XamlCompletion.cs
+++ b/AvaloniaVS/IntelliSense/XamlCompletion.cs
@@ -74,10 +74,12 @@ namespace AvaloniaVS.IntelliSense
 
             s_images = new ImageSource[capacity];
             s_images[(int)CompletionKind.Property] = LoadImage(imageService, KnownMonikers.Property, ref attributes);
+            s_images[(int)CompletionKind.Event] = LoadImage(imageService, KnownMonikers.Event, ref attributes);
             s_images[(int)CompletionKind.Class] = LoadImage(imageService, KnownMonikers.MarkupTag, ref attributes);
             s_images[(int)CompletionKind.Enum] = LoadImage(imageService, KnownMonikers.EnumerationItemPublic, ref attributes);
             s_images[(int)CompletionKind.Namespace] = LoadImage(imageService, KnownMonikers.Namespace, ref attributes);
 
+            s_images[(int)CompletionKind.AttachedEvent] = s_images[(int)CompletionKind.Event];
             s_images[(int)CompletionKind.AttachedProperty] = s_images[(int)CompletionKind.Property];
             s_images[(int)CompletionKind.StaticProperty] = s_images[(int)CompletionKind.Property];
             s_images[(int)CompletionKind.MarkupExtension] = s_images[(int)CompletionKind.Namespace];


### PR DESCRIPTION
## What does the pull request do?
Add intellisense completion for event and attached events

## What is the current behavior?
There is no completion for event or attached event


## What is the updated/expected behavior with this PR?
When typing name of event it is completed.
When typing name of type, which has attached events it is completed
When typing name of type, which has attached events + dot it will complete event name
Try typing event name ie. `KeyUp` on control, or `Gestures.*` for attached event

## How was the solution implemented (if it's not obvious)?
Events are straightforward. Dnlib does not differentiate between public and private events (idk if this is how framework works), so all are provided.

For attached properties I am looking for public static fields and (return type starts with `RoutedEvent` `or` name ends with `Event`).
I am not sure if `or` should be changed to `and`. Also maybe there is need for checking static properties?

## Fixed issues
#133

Also see PR on Avalonia.Ide
https://github.com/kekekeks/Avalonia.Ide/pull/26