### PR TITLE
update Avalonia.Ide and some improvements

### DIFF
--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -436,11 +436,20 @@ namespace AvaloniaVS.Views
             }
         }
 
+        private static Dictionary<string, Task<Metadata>> _metadataCache;
         private static async Task CreateCompletionMetadataAsync(
             string executablePath,
             XamlBufferMetadata target)
         {
-            await TaskScheduler.Default;
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (_metadataCache == null)
+            {
+                _metadataCache = new Dictionary<string, Task<Metadata>>();
+                var dte = (DTE)Package.GetGlobalService(typeof(DTE));
+
+                dte.Events.BuildEvents.OnBuildBegin += (s, e) => _metadataCache.Clear();
+            }
 
             Log.Logger.Verbose("Started AvaloniaDesigner.CreateCompletionMetadataAsync() for {ExecutablePath}", executablePath);
 
@@ -448,11 +457,19 @@ namespace AvaloniaVS.Views
             {
                 var sw = Stopwatch.StartNew();
 
-                target.CompletionMetadata = await Task.Run(() =>
+                Task<Metadata> metadataLoad;
+
+                if (!_metadataCache.TryGetValue(executablePath, out metadataLoad))
                 {
-                    var metadataReader = new MetadataReader(new DnlibMetadataProvider());
-                    return metadataReader.GetForTargetAssembly(executablePath);
-                });
+                    metadataLoad = Task.Run(() =>
+                                    {
+                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider());
+                                        return metadataReader.GetForTargetAssembly(executablePath);
+                                    });
+                    _metadataCache[executablePath] = metadataLoad;
+                }
+
+                target.CompletionMetadata = await metadataLoad;
 
                 target.NeedInvalidation = false;
 

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -95,6 +95,11 @@ namespace AvaloniaVS.Views
             previewer.Process = Process;
             pausedMessage.Visibility = Visibility.Collapsed;
             UpdateLayoutForView();
+
+            Loaded += (s, e) =>
+            {
+                StartStopProcessAsync().FireAndForget();
+            };
         }
 
         /// <summary>
@@ -332,7 +337,7 @@ namespace AvaloniaVS.Views
                     pausedMessage.Visibility = Visibility.Visible;
                     Process.Stop();
                 }
-                else if (!Process.IsRunning)
+                else if (!Process.IsRunning && IsLoaded)
                 {
                     pausedMessage.Visibility = Visibility.Collapsed;
 
@@ -344,7 +349,7 @@ namespace AvaloniaVS.Views
                     await StartProcessAsync();
                 }
             }
-            else
+            else if(!IsPaused && IsLoaded)
             {
                 RebuildMetadata(null, null);
                 Process.Stop();


### PR DESCRIPTION
Avalonia.Ide pr: https://github.com/kekekeks/Avalonia.Ide/pull/34 (merged)
update avalonia.ide as we will get support for:
- completions for using in xmlns like `xmlns:c="using:Avalonia.Data.Converters"`
- completions for static fields of static classes like` {x:Static ObjectConverters.IsNull}` etc.

added some optimization with great effect
 - only execute preview when designed is loaded and visible
 - cache completion metadata per target assembly, so we don't wait to build metadata on every designer window, but only on first

Fixes: #178 