### PR TITLE
Fix for #190 - taking assembly from debug rather than active configur…

### DIFF
--- a/AvaloniaVS/AvaloniaPackage.cs
+++ b/AvaloniaVS/AvaloniaPackage.cs
@@ -60,6 +60,7 @@ namespace AvaloniaVS
         public const string Name = "Avalonia Xaml Editor";
 
         public static SolutionService SolutionService { get; private set; }
+        public static UpdateSolutionEvents UpdateSolutionEvents { get; private set; }
 
         protected override async Task InitializeAsync(
             CancellationToken cancellationToken,
@@ -74,6 +75,9 @@ namespace AvaloniaVS
 
             var dte = (DTE)await GetServiceAsync(typeof(DTE));
             SolutionService = new SolutionService(dte);
+
+            UpdateSolutionEvents = new UpdateSolutionEvents(this, new ErrorListProvider(this));
+            await UpdateSolutionEvents.RegisterEventsAsync();
 
             Log.Logger.Information("Avalonia Package initialized");
         }

--- a/AvaloniaVS/AvaloniaVS.csproj
+++ b/AvaloniaVS/AvaloniaVS.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Services\AvaloniaVSSettings.cs" />
     <Compile Include="Services\IAvaloniaVSSettings.cs" />
     <Compile Include="Services\OutputPaneEventSink.cs" />
+    <Compile Include="Services\UpdateSolutionEvents.cs" />
     <Compile Include="Services\SolutionService.cs" />
     <Compile Include="Services\Throttle.cs" />
     <Compile Include="Services\EditorFactory.cs" />

--- a/AvaloniaVS/Services/UpdateSolutionEvents.cs
+++ b/AvaloniaVS/Services/UpdateSolutionEvents.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace AvaloniaVS.Services
+{
+    public class UpdateSolutionEvents : IVsUpdateSolutionEvents, IDisposable
+    {
+        private uint solutionUpdateCookie = 0;
+
+        public UpdateSolutionEvents(AsyncPackage asyncPackage, ErrorListProvider errorListProvider)
+        {
+            this.Package = asyncPackage ?? throw new ArgumentNullException(nameof(asyncPackage));
+            this.ErrorListProvider = errorListProvider ?? throw new ArgumentNullException(nameof(errorListProvider));
+        }
+
+        private ErrorListProvider ErrorListProvider { get; }
+
+        private AsyncPackage Package { get; }
+
+        /// <inheritdoc/>
+        public int UpdateSolution_Begin(ref int pfCancelUpdate)
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <inheritdoc/>
+        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <inheritdoc/>
+        public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
+        {
+            // On solution update, clear all errors generated
+            this.ErrorListProvider.Tasks.Clear();
+            return VSConstants.S_OK;
+        }
+
+        /// <inheritdoc/>
+        public int UpdateSolution_Cancel()
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <inheritdoc/>
+        public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
+        {
+            if(pIVsHierarchy != null)
+                ActiveProjectConfigurationDidChange?.Invoke(this, pIVsHierarchy);
+
+            return VSConstants.S_OK;
+        }
+
+
+        public event EventHandler<IVsHierarchy> ActiveProjectConfigurationDidChange;
+
+
+        /// <summary>
+        /// Asynchronously registers the solution eve
+        /// </summary>
+        /// <returns>Async task</returns>
+        public async System.Threading.Tasks.Task RegisterEventsAsync()
+        {
+            await this.Package.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (await this.Package.GetServiceAsync(typeof(SVsSolutionBuildManager)) is IVsSolutionBuildManager solutionBuildManager)
+            {
+                solutionBuildManager.AdviseUpdateSolutionEvents(this, out this.solutionUpdateCookie);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (this.solutionUpdateCookie > 0)
+            {
+                this.Package.JoinableTaskFactory.Run(async () =>
+                {
+                    await this.Package.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    if (await this.Package.GetServiceAsync(typeof(SVsSolutionBuildManager)) is IVsSolutionBuildManager solutionBuildManager)
+                    {
+                        solutionBuildManager.UnadviseUpdateSolutionEvents(this.solutionUpdateCookie);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS/Views/AvaloniaDesigner.xaml.cs
@@ -211,7 +211,27 @@ namespace AvaloniaVS.Views
             InitializeEditor();
             LoadTargetsAndStartProcessAsync().FireAndForget();
 
+            AvaloniaPackage.UpdateSolutionEvents.ActiveProjectConfigurationDidChange += (sender, vsh) => HandleConfigurationChangeAsync(sender, vsh).FireAndForget();
             Log.Logger.Verbose("Finished AvaloniaDesigner.Start()");
+        }
+
+        private async Task HandleConfigurationChangeAsync(object sender, Microsoft.VisualStudio.Shell.Interop.IVsHierarchy e)
+        {
+            /* We don't actually use the IVsHierarchy argument, but I thought I would...Given I'm looking for an opinion on this hack / 
+             * 'solution', then I'm leaving it in for the moment. I'm also thinking there probably exists a better of doing this, but I wanted to throw 
+             * together a first attempt at fixing the issue and then I'll tidy up. 
+             * 
+             * I'm thinking that UpdateSolutionEvents functionality could be merged into SolutionService 
+             */
+
+            //Lets pause the designer           
+            Process.Stop();
+
+            //Update targets
+            await LoadTargetsAsync();
+
+            //Start the designer again
+            await StartProcessAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
This is my first attempt at fixing #190

**Do not merge. Can we discuss?**

I'm not expecting it to be merged (please don't). Instead, I'm looking for an opinion / guidance that I'm heading in the right direction with this fix.

I'm thinking that if hooking into IVsUpdateSolutionEvents is correct, then perhaps SolutionService should implement it so I can remove UpdateSolutionEvents class entirely. 

I'm still not 100% sure why anyone would need the designer assembly to come from the active configuration, but it's an interesting excuse for me to dig into the extension anyway. 