### PR TITLE
Update vm image to windows 2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 pool:
-  vmImage: 'VS2017-Win2016'
+  vmImage: 'windows-2019'
 
 variables:
   solution: 'AvaloniaVS.sln'


### PR DESCRIPTION
Win2016 is outdated and will be deprecated soon.
![image](https://user-images.githubusercontent.com/53405089/139259627-6455d383-4d71-45ea-a4b9-b081a961f470.png)
