### PR TITLE
Fix "When you open a axaml\xaml file in VS with this extension it will appear in VS git as changed "

### DIFF
--- a/AvaloniaVS/Services/EditorFactory.cs
+++ b/AvaloniaVS/Services/EditorFactory.cs
@@ -141,7 +141,7 @@ namespace AvaloniaVS.Services
 
                 var guidIVSTextLines = typeof(IVsTextLines).GUID;
                 ErrorHandler.ThrowOnFailure(invisibleEditor.GetDocData(
-                    fEnsureWritable: 1,
+                    fEnsureWritable: 0,
                     riid: ref guidIVSTextLines,
                     ppDocData: out var docDataPointer));
 


### PR DESCRIPTION
This code fixes the problem on vs2019, on vs2022 this problem doesn't appear so that should be a VS bug. Btw I am not sure whether this will break something or not because I am not familiar with this code.
closes #220 