### PR TITLE
Fix #231 - Ctrl-F not opening the quick search box in VS2022

### DIFF
--- a/AvaloniaVS.Shared/Services/IVsFindTarget3.cs
+++ b/AvaloniaVS.Shared/Services/IVsFindTarget3.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace AvaloniaVS.Services
+// Do not change the namespace; otherwise, search box is broken in VS2022
+namespace Microsoft.VisualStudio.Editor.Internal
 {
     [ComImport]
+    [TypeIdentifier]
     [Guid("A2F0D62B-D0DD-4C59-AAB8-79CD20785451")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IVsFindTarget3

--- a/AvaloniaVS.Shared/Views/EditorHostPane.cs
+++ b/AvaloniaVS.Shared/Views/EditorHostPane.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using AvaloniaVS.Services;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Editor.Internal;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-	<UseCodebase>true</UseCodebase>
+    <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -89,10 +89,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AvaloniaVS.VS2019AndEarlier\AvaloniaVS.VS2019AndEarlier.csproj">
-      <Project>{79a4832c-9d3e-42d9-9215-d786565269b5}</Project>
-      <Name>AvaloniaVS.VS2019AndEarlier</Name>
-    </ProjectReference>
     <ProjectReference Include="..\submodules\Avalonia.Ide\src\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj">
       <Project>{317c91b4-1cb9-4bf2-8d5a-075ca214bf7c}</Project>
       <Name>Avalonia.Ide.CompletionEngine.DnlibMetadataProvider</Name>


### PR DESCRIPTION
This should fix #231 

As explained [here](https://github.com/AvaloniaUI/AvaloniaVS/issues/231#issuecomment-1032380289), I'm not very proud of this, but hey... it seems to work.

I've ensured it fixes the issue in VS2022 and it keeps working in VS2019 (could not test in VS2017, but there's no reason it shouldn't work)

PS: I also took the liberty to remove the reference to `AvaloniaVS.VS2019AndEarlier` from the `AvaloniaVS.VS2022` as it only had Visual Studio scream about duplicate symbols... If there was a legit reason for this reference, I'll add it again of course.