### PR TITLE
Change AvaloniaWindowTemplate extension from .xaml to .axaml

### DIFF
--- a/templates/AvaloniaWindowTemplate/AvaloniaWindowTemplate.vstemplate
+++ b/templates/AvaloniaWindowTemplate/AvaloniaWindowTemplate.vstemplate
@@ -7,7 +7,7 @@
     <TemplateID>f50b29b4-8396-45e8-9668-9b944681d371</TemplateID>
     <ProjectType>CSharp</ProjectType>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
-    <DefaultName>Window.xaml</DefaultName>
+    <DefaultName>Window.axaml</DefaultName>
   </TemplateData>
   <TemplateContent>
     <ProjectItem ItemType="AvaloniaXaml" ReplaceParameters="true" TargetFileName="$fileinputname$.axaml">Window.axaml</ProjectItem>


### PR DESCRIPTION
In the Avalonia Window template, the displayed default filename ends in .xaml, unlike all of the other templates which show .axaml. Functionally this doesn't matter because the generated files end up with .axaml extensions anyway, but this fix may eliminate some confusion. 

![image](https://user-images.githubusercontent.com/10566929/165464166-fabd7dc0-df2d-4158-9ab7-918607b5e729.png)
