### PR TITLE
use sensible hardcoded delta value for zooming.

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaPreviewer.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaPreviewer.xaml.cs
@@ -84,7 +84,7 @@ namespace AvaloniaVS.Views
 
                 if (designer.TryProcessZoomLevelValue(out var currentZoomLevel))
                 {
-                    currentZoomLevel += e.Delta * 0.01;
+                    currentZoomLevel += e.Delta > 0 ? 0.25 : -0.25;
 
                     if (currentZoomLevel < 0.125)
                     {


### PR DESCRIPTION
Zooming with non-precision mouse would make huge zoom level jumps