### PR TITLE
Remove InitializeComponent from the templates

### DIFF
--- a/templates/AvaloniaUserControlTemplate/UserControl.axaml.cs
+++ b/templates/AvaloniaUserControlTemplate/UserControl.axaml.cs
@@ -10,10 +10,5 @@ namespace $rootnamespace$
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/templates/AvaloniaUserControlTemplate/UserControl.axaml.cs
+++ b/templates/AvaloniaUserControlTemplate/UserControl.axaml.cs
@@ -1,6 +1,4 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace $rootnamespace$
 {

--- a/templates/AvaloniaWindowTemplate/Window.axaml.cs
+++ b/templates/AvaloniaWindowTemplate/Window.axaml.cs
@@ -1,6 +1,4 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace $rootnamespace$
 {
@@ -9,14 +7,6 @@ namespace $rootnamespace$
         public $safeitemrootname$()
         {
             InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }


### PR DESCRIPTION
InitializeComponent is generated by the source generator now. We don't need this in the user code anymore.

Fixes https://github.com/AvaloniaUI/AvaloniaVS/issues/249
And related https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/77