### PR TITLE
Use lazy loading for project references

### DIFF
--- a/AvaloniaVS.Shared/Models/ProjectInfo.cs
+++ b/AvaloniaVS.Shared/Models/ProjectInfo.cs
@@ -8,6 +8,8 @@ namespace AvaloniaVS.Models
     /// </summary>
     internal class ProjectInfo
     {
+        private IReadOnlyList<Project> _projectReferences;
+
         /// <summary>
         /// Gets or sets a value indicating whether the project is an executable.
         /// </summary>
@@ -33,10 +35,16 @@ namespace AvaloniaVS.Models
         /// </summary>
         public IReadOnlyList<ProjectOutputInfo> Outputs { get; set; }
 
+        public System.Lazy<IReadOnlyList<Project>> LazyProjectReferences { get; set; }
+
         /// <summary>
         /// Gets or sets the project's project references.
         /// </summary>
-        public IReadOnlyList<Project> ProjectReferences { get; set; }
+        public IReadOnlyList<Project> ProjectReferences
+        {
+            get => _projectReferences ?? (_projectReferences = LazyProjectReferences?.Value);
+            set => _projectReferences = value;
+        }
 
         /// <summary>
         /// Gets or sets the project's assembly references.

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -318,9 +318,9 @@ namespace AvaloniaVS.Views
 
                 bool IsValidTarget(ProjectInfo project)
                 {
-                    return (project.Project == _project || project.ProjectReferences.Contains(_project)) &&
-                        project.IsExecutable &&
-                        project.References.Contains("Avalonia.DesignerSupport");
+                    return project.IsExecutable && 
+                        project.References.Contains("Avalonia.DesignerSupport") &&
+                        (project.Project == _project || project.ProjectReferences.Contains(_project));
                 }
 
                 bool IsValidOutput(ProjectOutputInfo output)


### PR DESCRIPTION
This pull request enables lazy loading for project references.

Background: we have solution with over 200 projects, each referencing each other. As result opening an editor takes 7 minutes, because of huge amount of references, that must be processed. Now it takes several seconds, because `ProjectReferences` won't be loaded if it's not necessary