### PR TITLE
Add VS specific CompletionEngine

### DIFF
--- a/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
+++ b/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
@@ -11,6 +11,13 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AvaloniaPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\ViewCodeCommandHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\IAvVSAssemblyInformation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Manipulation\AvVSCloseXmlTagManipulation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Manipulation\AvVSTextManipulator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Metadata\AvVSDnLibMetadataProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Metadata\AvVSMetadataConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Metadata\AvVSMetadataReader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\Metadata\MetadataUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EnumToIntConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EnumValuesConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\NotNullOrEmptyToVisibilityConverter.cs" />

--- a/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
+++ b/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AvaloniaPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\ViewCodeCommandHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Completion\AvVSCompletionEngine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Completion\IAvVSAssemblyInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Completion\Manipulation\AvVSCloseXmlTagManipulation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Completion\Manipulation\AvVSTextManipulator.cs" />

--- a/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
+++ b/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
@@ -1,0 +1,662 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine;
+using System.Text.RegularExpressions;
+using System.Xml;
+using AvMetadata = Avalonia.Ide.CompletionEngine.Metadata;
+using AvaloniaVS.Shared.Completion.Metadata;
+using AvCompletion = Avalonia.Ide.CompletionEngine.Completion;
+
+namespace AvaloniaVS.Shared.Completion
+{
+    public class AvVSCompletionEngine
+    {
+        private class MetadataHelper
+        {
+            private AvMetadata _metadata;
+            public AvMetadata Metadata => _metadata;
+            public Dictionary<string, string> Aliases { get; private set; }
+
+            private Dictionary<string, MetadataType> _types;
+            private string _currentAssemblyName;
+
+            public void SetMetadata(AvMetadata metadata, string xml, string currentAssemblyName = null)
+            {
+                var aliases = GetNamespaceAliases(xml);
+
+                //Check if metadata and aliases can be reused
+                if (_metadata == metadata && Aliases != null && _types != null && currentAssemblyName == _currentAssemblyName)
+                {
+                    if (aliases.Count == Aliases.Count)
+                    {
+                        bool mismatch = false;
+                        foreach (var alias in aliases)
+                        {
+                            if (!Aliases.ContainsKey(alias.Key) || Aliases[alias.Key] != alias.Value)
+                            {
+                                mismatch = true;
+                                break;
+                            }
+                        }
+
+                        if (!mismatch)
+                            return;
+                    }
+                }
+                Aliases = aliases;
+                _metadata = metadata;
+                _types = null;
+                _currentAssemblyName = currentAssemblyName;
+
+                var types = new Dictionary<string, MetadataType>();
+                foreach (var alias in Aliases.Concat(new[] { new KeyValuePair<string, string>("", "") }))
+                {
+                    Dictionary<string, MetadataType> ns;
+
+                    string aliasValue = alias.Value ?? "";
+
+                    if (!string.IsNullOrEmpty(_currentAssemblyName) && aliasValue.StartsWith("clr-namespace:") && !aliasValue.Contains(";assembly="))
+                        aliasValue = $"{aliasValue};assembly={_currentAssemblyName}";
+
+                    if (!metadata.Namespaces.TryGetValue(aliasValue, out ns))
+                        continue;
+
+                    var prefix = alias.Key.Length == 0 ? "" : (alias.Key + ":");
+                    foreach (var type in ns.Values)
+                        types[prefix + type.Name] = type;
+                }
+
+                _types = types;
+            }
+
+            public IEnumerable<KeyValuePair<string, MetadataType>> FilterTypes(string prefix, bool withAttachedPropertiesOrEventsOnly = false, bool markupExtensionsOnly = false, bool staticGettersOnly = false, bool xamlDirectiveOnly = false)
+            {
+                prefix = prefix ?? "";
+
+                var e = _types
+                    .Where(t => t.Value.IsXamlDirective == xamlDirectiveOnly && t.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+                if (withAttachedPropertiesOrEventsOnly)
+                    e = e.Where(t => t.Value.HasAttachedProperties || t.Value.HasAttachedEvents);
+                if (markupExtensionsOnly)
+                    e = e.Where(t => t.Value.IsMarkupExtension);
+                if (staticGettersOnly)
+                    e = e.Where(t => t.Value.HasStaticGetProperties);
+
+                return e;
+            }
+
+            public IEnumerable<string> FilterTypeNames(string prefix, bool withAttachedPropertiesOrEventsOnly = false, bool markupExtensionsOnly = false, bool staticGettersOnly = false, bool xamlDirectiveOnly = false)
+            {
+                return FilterTypes(prefix, withAttachedPropertiesOrEventsOnly, markupExtensionsOnly, staticGettersOnly, xamlDirectiveOnly).Select(s => s.Key);
+            }
+
+            public MetadataType LookupType(string name)
+            {
+                MetadataType rv;
+                _types.TryGetValue(name, out rv);
+                return rv;
+            }
+
+            public IEnumerable<string> FilterPropertyNames(string typeName, string propName,
+                bool? attached,
+                bool hasSetter,
+                bool staticGetter = false)
+            {
+                var t = LookupType(typeName);
+                return FilterPropertyNames(t, propName, attached, hasSetter, staticGetter);
+            }
+
+            public IEnumerable<string> FilterPropertyNames(MetadataType t, string propName,
+                bool? attached,
+                bool hasSetter,
+                bool staticGetter = false)
+            {
+
+                propName = propName ?? "";
+                if (t == null)
+                    return new string[0];
+
+                var e = t.Properties.Where(p => p.Name.StartsWith(propName, StringComparison.OrdinalIgnoreCase) && (hasSetter ? p.HasSetter : p.HasGetter));
+
+                if (attached.HasValue)
+                    e = e.Where(p => p.IsAttached == attached);
+                if (staticGetter)
+                    e = e.Where(p => p.IsStatic && p.HasGetter);
+                else
+                    e = e.Where(p => !p.IsStatic);
+
+                return e.Select(p => p.Name);
+            }
+
+            public IEnumerable<string> FilterEventNames(string typeName, string propName,
+                bool attached)
+            {
+                var t = LookupType(typeName);
+                propName = propName ?? "";
+                if (t == null)
+                    return new string[0];
+
+                return t.Events.Where(n => n.IsAttached == attached && n.Name.StartsWith(propName)).Select(n => n.Name);
+            }
+
+            public MetadataProperty LookupProperty(string typeName, string propName)
+                => LookupType(typeName)?.Properties?.FirstOrDefault(p => p.Name == propName);
+        }
+
+        private MetadataHelper _helper = new MetadataHelper();
+
+        private static Dictionary<string, string> GetNamespaceAliases(string xml)
+        {
+            var rv = new Dictionary<string, string>();
+            try
+            {
+                var xmlRdr = XmlReader.Create(new StringReader(xml));
+                bool result = true;
+                while (result && xmlRdr.NodeType != XmlNodeType.Element)
+                {
+                    try
+                    {
+                        result = xmlRdr.Read();
+                    }
+                    catch
+                    {
+                        if (xmlRdr.NodeType != XmlNodeType.Element)
+                            result = false;
+                    }
+                }
+
+                if (result)
+                {
+                    for (var c = 0; c < xmlRdr.AttributeCount; c++)
+                    {
+                        xmlRdr.MoveToAttribute(c);
+                        var ns = xmlRdr.Name;
+                        if (ns != "xmlns" && !ns.StartsWith("xmlns:"))
+                            continue;
+                        ns = ns == "xmlns" ? "" : ns.Substring(6);
+                        rv[ns] = xmlRdr.Value;
+                    }
+                }
+            }
+            catch
+            {
+                //
+            }
+            if (!rv.ContainsKey(""))
+                rv[""] = MetadataUtils.AvaloniaNamespace;
+            return rv;
+        }
+
+        public CompletionSet GetCompletions(AvMetadata metadata, string fullText, int pos, string currentAssemblyName = null)
+        {
+            string textToCursor = fullText.Substring(0, pos);
+            _helper.SetMetadata(metadata, textToCursor, currentAssemblyName);
+
+            if (_helper.Metadata == null)
+                return null;
+
+            if (fullText.Length == 0 || pos == 0)
+                return null;
+            var state = XmlParser.Parse(textToCursor);
+
+            var completions = new List<AvCompletion>();
+
+            int curStart = state.CurrentValueStart ?? 0;
+
+            if (state.State == XmlParser.ParserState.StartElement)
+            {
+                var tagName = state.TagName;
+                if (tagName.StartsWith("/"))
+                {
+                    if (textToCursor.Length < 2)
+                        return null;
+                    var closingState = XmlParser.Parse(textToCursor.Substring(0, textToCursor.Length - 2));
+
+                    var name = closingState.GetParentTagName(0);
+                    if (name == null)
+                        return null;
+                    completions.Add(new AvCompletion("/" + name + ">", CompletionKind.Class));
+                }
+                else if (tagName.Contains("."))
+                {
+                    var dotPos = tagName.IndexOf(".");
+                    var typeName = tagName.Substring(0, dotPos);
+                    var compName = tagName.Substring(dotPos + 1);
+                    curStart = curStart + dotPos + 1;
+
+                    var sameType = state.GetParentTagName(1) == typeName;
+
+                    completions.AddRange(_helper.FilterPropertyNames(typeName, compName, attached: sameType ? (bool?)null : true, hasSetter: false)
+                        .Select(p => new AvCompletion(p, sameType ? CompletionKind.Property : CompletionKind.AttachedProperty)));
+                }
+                else
+                    completions.AddRange(_helper.FilterTypeNames(tagName).Select(x => new AvCompletion(x, CompletionKind.Class)));
+            }
+            else if (state.State == XmlParser.ParserState.InsideElement ||
+                     state.State == XmlParser.ParserState.StartAttribute)
+            {
+                if (state.State == XmlParser.ParserState.InsideElement)
+                    curStart = pos; //Force completion to be started from current cursor position
+
+                string attributeSuffix = "=\"\"";
+                int attributeOffset = 2;
+                if (fullText.Length > pos && fullText[pos] == '=')
+                {
+                    // attribute already has value, we are editing name only
+                    attributeSuffix = "";
+                    attributeOffset = 0;
+                }
+
+                if (state.AttributeName?.Contains(".") == true)
+                {
+                    var dotPos = state.AttributeName.IndexOf('.');
+                    curStart += dotPos + 1;
+                    var split = state.AttributeName.Split(new[] { '.' }, 2);
+                    completions.AddRange(_helper.FilterPropertyNames(split[0], split[1], attached: true, hasSetter: true)
+                        .Select(x => new AvCompletion(x, x + attributeSuffix, x, CompletionKind.AttachedProperty, x.Length + attributeOffset)));
+
+                    completions.AddRange(_helper.FilterEventNames(split[0], split[1], attached: true)
+                        .Select(v => new AvCompletion(v, v + attributeSuffix, v, CompletionKind.AttachedEvent, v.Length + attributeOffset)));
+                }
+                else
+                {
+                    completions.AddRange(_helper.FilterPropertyNames(state.TagName, state.AttributeName, attached: false, hasSetter: true)
+                        .Select(x => new AvCompletion(x, x + attributeSuffix, x, CompletionKind.Property, x.Length + attributeOffset)));
+
+                    completions.AddRange(_helper.FilterEventNames(state.TagName, state.AttributeName, attached: false)
+                        .Select(v => new AvCompletion(v, v + attributeSuffix, v, CompletionKind.Event, v.Length + attributeOffset)));
+
+                    var targetType = _helper.LookupType(state.TagName);
+                    completions.AddRange(
+                        _helper.FilterTypes(state.AttributeName, xamlDirectiveOnly: true)
+                            .Where(t => t.Value.IsValidForXamlContextFunc?.Invoke(currentAssemblyName, targetType, null) ?? true)
+                            .Select(v => new AvCompletion(v.Key, v.Key + attributeSuffix, v.Key, CompletionKind.Class, v.Key.Length + attributeOffset)));
+
+                    if (targetType?.IsAvaloniaObjectType == true)
+                        completions.AddRange(
+                            _helper.FilterTypeNames(state.AttributeName, withAttachedPropertiesOrEventsOnly: true)
+                                .Select(v => new AvCompletion(v, v + ".", v, CompletionKind.Class)));
+                }
+            }
+            else if (state.State == XmlParser.ParserState.AttributeValue)
+            {
+                MetadataProperty prop;
+                if (state.AttributeName.Contains("."))
+                {
+                    //Attached property
+                    var split = state.AttributeName.Split('.');
+                    prop = _helper.LookupProperty(split[0], split[1]);
+                }
+                else
+                    prop = _helper.LookupProperty(state.TagName, state.AttributeName);
+
+                //Markup extension, ignore everything else
+                if (state.AttributeValue.StartsWith("{"))
+                {
+                    curStart = state.CurrentValueStart.Value +
+                               BuildCompletionsForMarkupExtension(prop, completions, fullText, state,
+                                   textToCursor.Substring(state.CurrentValueStart.Value), currentAssemblyName);
+                }
+                else
+                {
+                    prop = prop ?? _helper.LookupType(state.AttributeName)?.Properties.FirstOrDefault(p => p.Name == "");
+
+                    if (prop?.Type?.HasHintValues == true)
+                    {
+                        var search = textToCursor.Substring(state.CurrentValueStart.Value);
+                        if (prop.Type.IsCompositeValue)
+                        {
+                            var last = search.Split(' ', ',').LastOrDefault();
+                            curStart = curStart + search.Length - last?.Length ?? 0;
+                            search = last;
+                        }
+
+                        completions.AddRange(GetHintCompletions(prop.Type, search, currentAssemblyName));
+                    }
+                    else if (prop?.Type?.Name == typeof(Type).FullName)
+                    {
+                        completions.AddRange(_helper.FilterTypeNames(state.AttributeValue).Select(x => new AvCompletion(x, x, x, CompletionKind.Class)));
+                    }
+                    else if (state.AttributeName == "xmlns" || state.AttributeName.Contains("xmlns:"))
+                    {
+                        if (state.AttributeValue.StartsWith("clr-namespace:"))
+                            completions.AddRange(
+                                metadata.Namespaces.Keys.Where(v => v.StartsWith(state.AttributeValue))
+                                    .Select(v => new AvCompletion(v.Substring("clr-namespace:".Length), v, v, CompletionKind.Namespace)));
+                        else
+                        {
+                            if ("using:".StartsWith(state.AttributeValue))
+                                completions.Add(new AvCompletion("using:", CompletionKind.Namespace));
+
+                            if ("clr-namespace:".StartsWith(state.AttributeValue))
+                                completions.Add(new AvCompletion("clr-namespace:", CompletionKind.Namespace));
+
+                            completions.AddRange(
+                                metadata.Namespaces.Keys.Where(
+                                    v =>
+                                        v.StartsWith(state.AttributeValue) &&
+                                        !v.StartsWith("clr-namespace"))
+                                    .Select(v => new AvCompletion(v, CompletionKind.Namespace)));
+                        }
+                    }
+                    else if (state.AttributeName.EndsWith(":Class"))
+                    {
+                        if (_helper.Aliases.TryGetValue(state.AttributeName.Replace(":Class", ""), out var ns) && ns == MetadataUtils.Xaml2006Namespace)
+                        {
+                            var asmKey = $";assembly={currentAssemblyName}";
+                            var fullClassNames = _helper.Metadata.Namespaces.Where(v => v.Key.EndsWith(asmKey))
+                                                                            .SelectMany(v => v.Value.Values.Where(t => t.IsAvaloniaObjectType))
+                                                                            .Select(v => v.FullName);
+                            completions.AddRange(
+                                   fullClassNames
+                                    .Where(v => v.StartsWith(state.AttributeValue))
+                                    .Select(v => new AvCompletion(v, CompletionKind.Class)));
+                        }
+                    }
+                    else if (state.TagName == "Setter" && (state.AttributeName == "Value" || state.AttributeName == "Property"))
+                    {
+                        ProcessStyleSetter(state.AttributeName, state, completions, currentAssemblyName);
+                    }
+                }
+            }
+
+            if (completions.Count != 0)
+                return new CompletionSet() { Completions = completions, StartPosition = curStart };
+            return null;
+        }
+
+        private void ProcessStyleSetter(string setterPropertyName, XmlParser state, List<AvCompletion> completions, string currentAssemblyName)
+        {
+            const string selectorTypes = @"(?<type>([\w|])+)|([:\.#/]\w+)";
+
+            var selector = state.FindParentAttributeValue("Selector", 1, maxLevels: 0);
+            var matches = Regex.Matches(selector ?? "", selectorTypes);
+            var types = matches.OfType<Match>().Select(m => m.Groups["type"].Value).Where(v => !string.IsNullOrEmpty(v));
+            var selectorTypeName = types.LastOrDefault()?.Replace('|', ':') ?? "Control";
+
+            if (string.IsNullOrEmpty(selectorTypeName))
+                return;
+
+            if (setterPropertyName == "Property")
+            {
+                string value = state.AttributeValue ?? "";
+
+                if (value.Contains("."))
+                {
+                    int curStart = state.CurrentValueStart ?? 0;
+                    var dotPos = value.IndexOf(".");
+                    var typeName = value.Substring(0, dotPos);
+                    var compName = value.Substring(dotPos + 1);
+                    curStart = curStart + dotPos + 1;
+
+                    var sameType = state.GetParentTagName(1) == typeName;
+
+                    completions.AddRange(_helper.FilterPropertyNames(typeName, compName, attached: true, hasSetter: true)
+                                    .Select(p => new AvCompletion(p, $"{typeName}.{p}", p, CompletionKind.AttachedProperty)));
+                }
+                else
+                {
+                    completions.AddRange(_helper.FilterPropertyNames(selectorTypeName, value, attached: false, hasSetter: true)
+                            .Select(x => new AvCompletion(x, CompletionKind.Property)));
+
+                    completions.AddRange(_helper.FilterTypeNames(value, withAttachedPropertiesOrEventsOnly: true).Select(x => new AvCompletion(x, CompletionKind.Class)));
+                }
+
+            }
+            else if (setterPropertyName == "Value")
+            {
+                var setterProperty = state.FindParentAttributeValue("Property", maxLevels: 0);
+
+                if (setterProperty.Contains("."))
+                {
+                    var vals = setterProperty.Split('.');
+                    selectorTypeName = vals[0];
+                    setterProperty = vals[1];
+                }
+
+                var setterProp = _helper.LookupProperty(selectorTypeName, setterProperty);
+                if (setterProp?.Type?.HasHintValues == true)
+                {
+                    completions.AddRange(GetHintCompletions(setterProp.Type, state.AttributeValue, currentAssemblyName));
+                }
+            }
+        }
+
+        public IEnumerable<string> FilterHintValues(MetadataType type, string entered, string currentAssemblyName, XmlParser state)
+        {
+            entered = entered ?? "";
+
+            if (type == null)
+                yield break;
+
+            if (!string.IsNullOrEmpty(currentAssemblyName) && type.XamlContextHintValuesFunc != null)
+            {
+                foreach (var v in type.XamlContextHintValuesFunc(currentAssemblyName, type, null).Where(v => v.StartsWith(entered, StringComparison.OrdinalIgnoreCase)))
+                {
+                    yield return v;
+                }
+            }
+
+            foreach (var v in type.HintValues.Where(v => v.StartsWith(entered, StringComparison.OrdinalIgnoreCase)))
+            {
+                yield return v;
+            }
+        }
+
+        private IEnumerable<AvCompletion> FilterHintValuesForBindingPath(MetadataType bindingPathType, string entered, string currentAssemblyName, string fullText, XmlParser state)
+        {
+            IEnumerable<AvCompletion> forPropertiesFromType(MetadataType filterType, string filter, Func<string, string> fmtInsertText = null)
+            {
+                if (filterType != null)
+                {
+                    foreach (var propertyName in _helper.FilterPropertyNames(filterType, filter, false, false))
+                    {
+                        yield return new AvCompletion(propertyName, fmtInsertText?.Invoke(propertyName) ?? propertyName, propertyName, CompletionKind.Property);
+                    }
+                }
+            }
+
+            IEnumerable<AvCompletion> forProperties(string filterType, string filter, Func<string, string> fmtInsertText = null)
+                    => forPropertiesFromType(_helper.LookupType(filterType ?? ""), filter, fmtInsertText);
+
+            if (string.IsNullOrEmpty(entered))
+                return forProperties(state.FindParentAttributeValue("(x\\:)?DataType"), entered);
+
+            var values = entered.Split('.');
+
+            if (values.Length == 1)
+            {
+                if (values[0].StartsWith("$parent["))
+                {
+                    return _helper.FilterTypes(entered.Substring("$parent[".Length))
+                        .Select(v => new AvCompletion(v.Key, $"$parent[{v.Key}].", v.Key, CompletionKind.Class));
+                }
+                else if (values[0].StartsWith("#"))
+                {
+                    var nameMatch = Regex.Matches(fullText, $"\\s(?:(x\\:)?Name)=\"(?<AttribValue>[\\w\\:\\s\\|\\.]+)\"");
+
+                    if (nameMatch.Count > 0)
+                    {
+                        var result = new List<AvCompletion>();
+                        foreach (Match m in nameMatch)
+                        {
+                            if (m.Success)
+                            {
+                                var name = m.Groups["AttribValue"].Value;
+                                result.Add(new AvCompletion(name, $"#{name}", name, CompletionKind.Class));
+                            }
+                        }
+                        return result;
+                    }
+
+                    return Array.Empty<AvCompletion>();
+                }
+
+                return forProperties(state.FindParentAttributeValue("(x\\:)?DataType"), entered);
+            }
+
+            string type = values[0];
+
+            int i;
+
+            if (values[0].StartsWith("$"))
+            {
+                i = 1;
+                type = "Control";
+                if (values[0] == "$self") //current control type
+                    type = state.GetParentTagName(0);
+                else if (values[0] == "$parent") //parent control in the xaml
+                    type = state.GetParentTagName(1) ?? "Control";
+                else if (values[0].StartsWith("$parent[")) //extract parent type
+                    type = values[0].Substring("$parent[".Length, values[0].Length - "$parent[".Length - 1);
+            }
+            else if (values[0].StartsWith("#"))
+            {
+                i = 1;
+                //todo: find the control type etc ???
+                type = "Control";
+            }
+            else
+            {
+                i = 0;
+                type = state.FindParentAttributeValue("(x\\:)?DataType");
+            }
+
+            var mdType = _helper.LookupType(type ?? "");
+
+            while (mdType != null && i < values.Length - 1 && !string.IsNullOrEmpty(values[i]))
+            {
+                if (i <= 1 && values[i] == "DataContext")
+                {
+                    //assume parent.datacontext is x:datatype so we have some intelisence
+                    type = state.FindParentAttributeValue("(x\\:)?DataType");
+                    mdType = _helper.LookupType(type);
+                }
+                else
+                {
+                    mdType = mdType.Properties.FirstOrDefault(p => p.Name == values[i])?.Type;
+                    type = mdType?.FullName;
+                }
+                i++;
+            }
+
+            return forPropertiesFromType(mdType, values[i], p => $"{string.Join(".", values.Take(i).ToArray())}.{p}");
+        }
+
+        private List<AvCompletion> GetHintCompletions(MetadataType type, string entered, string currentAssemblyName = null, string fullText = null, XmlParser state = null)
+        {
+            var kind = GetCompletionKindForHintValues(type);
+
+            var completions = FilterHintValues(type, entered, currentAssemblyName, state)
+                .Select(val => new AvCompletion(val, kind)).ToList();
+
+            if (type.FullName == "{BindingPath}" && state != null)
+            {
+                completions.AddRange(FilterHintValuesForBindingPath(type, entered, currentAssemblyName, fullText, state));
+            }
+            return completions;
+        }
+
+        private int BuildCompletionsForMarkupExtension(MetadataProperty property, List<AvCompletion> completions, string fullText, XmlParser state, string data, string currentAssemblyName)
+        {
+            int? forcedStart = null;
+            var ext = MarkupExtensionParser.Parse(data);
+
+            var transformedName = (ext.ElementName ?? "").Trim();
+            if (_helper.LookupType(transformedName)?.IsMarkupExtension != true)
+                transformedName += "Extension";
+
+            if (ext.State == MarkupExtensionParser.ParserStateType.StartElement)
+                completions.AddRange(_helper.FilterTypeNames(ext.ElementName, markupExtensionsOnly: true)
+                    .Select(t => t.EndsWith("Extension") ? t.Substring(0, t.Length - "Extension".Length) : t)
+                    .Select(t => new AvCompletion(t, CompletionKind.MarkupExtension)));
+            if (ext.State == MarkupExtensionParser.ParserStateType.StartAttribute ||
+                ext.State == MarkupExtensionParser.ParserStateType.InsideElement)
+            {
+                if (ext.State == MarkupExtensionParser.ParserStateType.InsideElement)
+                    forcedStart = data.Length;
+
+                completions.AddRange(_helper.FilterPropertyNames(transformedName, ext.AttributeName ?? "", attached: false, hasSetter: true)
+                    .Select(x => new AvCompletion(x, x + "=", x, CompletionKind.Property)));
+
+                var attribName = ext.AttributeName ?? "";
+                var t = _helper.LookupType(transformedName);
+
+                bool ctorArgument = ext.AttributesCount == 0;
+                //skip ctor hints when some property is already set
+                if (t != null && t.IsMarkupExtension && t.SupportCtorArgument != MetadataTypeCtorArgument.None && ctorArgument)
+                {
+                    if (t.SupportCtorArgument == MetadataTypeCtorArgument.HintValues)
+                    {
+                        if (t.HasHintValues)
+                        {
+                            completions.AddRange(GetHintCompletions(t, attribName));
+                        }
+                    }
+                    else if (attribName.Contains("."))
+                    {
+                        if (t.SupportCtorArgument != MetadataTypeCtorArgument.Type)
+                        {
+                            var split = attribName.Split('.');
+                            var type = split[0];
+                            var prop = split[1];
+
+                            var mType = _helper.LookupType(type);
+                            if (mType != null && t.SupportCtorArgument == MetadataTypeCtorArgument.HintValues)
+                            {
+                                var hints = FilterHintValues(mType, prop, currentAssemblyName, state);
+                                completions.AddRange(hints.Select(x => new AvCompletion(x, $"{type}.{x}", x, GetCompletionKindForHintValues(mType))));
+                            }
+
+                            var props = _helper.FilterPropertyNames(type, prop, attached: false, hasSetter: false, staticGetter: true);
+                            completions.AddRange(props.Select(x => new AvCompletion(x, $"{type}.{x}", x, CompletionKind.StaticProperty)));
+                        }
+                    }
+                    else
+                    {
+                        var types = _helper.FilterTypeNames(attribName,
+                            staticGettersOnly: t.SupportCtorArgument == MetadataTypeCtorArgument.Object);
+
+                        completions.AddRange(types.Select(x => new AvCompletion(x, x, x, CompletionKind.Class)));
+
+                        if (property?.Type?.HasHintValues == true)
+                        {
+                            completions.Add(new AvCompletion(property.Type.Name, property.Type.Name + ".", property.Type.Name, CompletionKind.Class));
+                        }
+                    }
+                }
+                else
+                {
+                    var defaultProp = t?.Properties.FirstOrDefault(p => p.Name == "");
+                    if (defaultProp?.Type?.HasHintValues ?? false)
+                    {
+                        completions.AddRange(GetHintCompletions(defaultProp.Type, ext.AttributeName ?? "", currentAssemblyName, fullText, state));
+                    }
+                }
+            }
+            if (ext.State == MarkupExtensionParser.ParserStateType.AttributeValue
+                || ext.State == MarkupExtensionParser.ParserStateType.BeforeAttributeValue)
+            {
+                var prop = _helper.LookupProperty(transformedName, ext.AttributeName);
+                if (prop?.Type?.HasHintValues == true)
+                {
+                    var start = data.Substring(ext.CurrentValueStart);
+                    completions.AddRange(GetHintCompletions(prop.Type, start, currentAssemblyName, fullText, state));
+                }
+            }
+
+            return forcedStart ?? ext.CurrentValueStart;
+        }
+
+        public static bool ShouldTriggerCompletionListOn(char typedChar)
+        {
+            return char.IsLetterOrDigit(typedChar) || typedChar == '/' || typedChar == '<'
+                || typedChar == ' ' || typedChar == '.' || typedChar == ':' || typedChar == '$' || typedChar == '#';
+        }
+
+        public static CompletionKind GetCompletionKindForHintValues(MetadataType type)
+            => type.IsEnum ? CompletionKind.Enum : CompletionKind.StaticProperty;
+    }
+}

--- a/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
+++ b/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
@@ -311,6 +311,12 @@ namespace AvaloniaVS.Shared.Completion
                             var last = search.Split(' ', ',').LastOrDefault();
                             curStart = curStart + search.Length - last?.Length ?? 0;
                             search = last;
+
+                            // Special case for pseudoclasses within the current edit
+                            if (state.AttributeName.Equals("Selector") && search.Contains(":"))
+                            {
+                                search = ":";
+                            }
                         }
 
                         completions.AddRange(GetHintCompletions(prop.Type, search, currentAssemblyName));
@@ -364,6 +370,7 @@ namespace AvaloniaVS.Shared.Completion
 
             if (completions.Count != 0)
                 return new CompletionSet() { Completions = completions, StartPosition = curStart };
+
             return null;
         }
 
@@ -653,7 +660,8 @@ namespace AvaloniaVS.Shared.Completion
         public static bool ShouldTriggerCompletionListOn(char typedChar)
         {
             return char.IsLetterOrDigit(typedChar) || typedChar == '/' || typedChar == '<'
-                || typedChar == ' ' || typedChar == '.' || typedChar == ':' || typedChar == '$' || typedChar == '#';
+                || typedChar == ' ' || typedChar == '.' || typedChar == ':' || typedChar == '$' 
+                || typedChar == '#' || typedChar == '-' || typedChar == '^';
         }
 
         public static CompletionKind GetCompletionKindForHintValues(MetadataType type)

--- a/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
+++ b/AvaloniaVS.Shared/Completion/AvVSCompletionEngine.cs
@@ -437,13 +437,6 @@ namespace AvaloniaVS.Shared.Completion
                     completions.AddRange(GetHintCompletions(setterProp.Type, state.AttributeValue, currentAssemblyName));
                 }
             }
-
-            //bool isControlTheme()
-            //{
-            //    var parentTag = state.GetParentTagName(state.NestingLevel - 1);
-                
-            //    return parentTag?.Equals("ControlTheme") ?? false;
-            //}
         }
 
         public IEnumerable<string> FilterHintValues(MetadataType type, string entered, string currentAssemblyName, XmlParser state)

--- a/AvaloniaVS.Shared/Completion/IAvVSAssemblyInformation.cs
+++ b/AvaloniaVS.Shared/Completion/IAvVSAssemblyInformation.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+
+namespace AvaloniaVS.Shared.Completion
+{
+    // NOTE: These types are added now to reuse the existing interfaces but allow
+    //       needed additions later, if needed for a feature
+
+    public interface IAvVSAssemblyInformation : IAssemblyInformation
+    {
+
+    }
+
+    public interface IAvVSTypeInformation : ITypeInformation
+    {
+
+    }
+
+    public interface IAvVSMethodInformation : IMethodInformation
+    {
+
+    }
+
+    public interface IAvVSFieldInformation : IFieldInformation
+    {
+
+    }
+
+    public interface IAvVSPropertyInformation : IPropertyInformation
+    {
+
+    }
+
+    public interface IAvVSEventInformation : IEventInformation
+    {
+
+    }
+}

--- a/AvaloniaVS.Shared/Completion/IAvVSAssemblyInformation.cs
+++ b/AvaloniaVS.Shared/Completion/IAvVSAssemblyInformation.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+﻿using System.Collections;
+using System.Collections.Generic;
+using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 
 namespace AvaloniaVS.Shared.Completion
 {
@@ -12,7 +14,7 @@ namespace AvaloniaVS.Shared.Completion
 
     public interface IAvVSTypeInformation : ITypeInformation
     {
-
+        IEnumerable<string> Pseudoclasses { get; }
     }
 
     public interface IAvVSMethodInformation : IMethodInformation

--- a/AvaloniaVS.Shared/Completion/Manipulation/AvVSCloseXmlTagManipulation.cs
+++ b/AvaloniaVS.Shared/Completion/Manipulation/AvVSCloseXmlTagManipulation.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Ide.CompletionEngine;
+
+namespace AvaloniaVS.Shared.Completion.Manipulation
+{
+    public class AvVSCloseXmlTagManipulation
+    {
+        private readonly XmlParser _state;
+        private readonly ReadOnlyMemory<char> _text;
+        private readonly int _position;
+
+        public AvVSCloseXmlTagManipulation(XmlParser state, ReadOnlyMemory<char> text, int position)
+        {
+            _state = state;
+            _text = text;
+            _position = position;
+        }
+
+        public void TryCloseTag(ITextChange textChange, IList<TextManipulation> manipulations)
+        {
+            var currentTag = _state.ParseCurrentTagName();
+            if (textChange.NewText == "/" && !string.IsNullOrEmpty(currentTag) && currentTag != "/")
+            {
+                var text = _text.Span;
+                int pos = _state.ParserPos;
+                char c = ' ';
+                while (char.IsWhiteSpace(c) && text.Length > pos + 1)
+                {
+                    pos++;
+                    c = text[pos];
+                }
+
+                bool tagAlreadyClosed = c == '>';
+                if (!tagAlreadyClosed)
+                {
+                    manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
+                }
+                else
+                {
+                    var closingTagPos = FindClosingTag(currentTag, pos + 1);
+                    if (closingTagPos != null)
+                    {
+                        manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
+                        manipulations.Add(TextManipulation.Delete(_position + 1, closingTagPos.Value - _position));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// If we just changed open tag to self-closing this finds closing tag if closed tag was empty
+        /// </summary>
+        /// <returns>Position of closing brace of closing tag if this tag is empty and self closing</returns>
+        private int? FindClosingTag(string currentTag, int startPos)
+        {
+            int pos = startPos;
+
+            var text = _text.Span;
+            if (pos >= text.Length)
+            {
+                return null;
+            }
+
+            pos = SkipWhitespace(pos, text);
+
+            // Check next text is </closingTag>
+            if (text.Length < pos + currentTag.Length + 3
+                || text[pos] != '<'
+                || text[pos + 1] != '/')
+            {
+                return null;
+            }
+
+            pos = pos + 2;
+            for (int i = 0; i < currentTag.Length; i++)
+            {
+                if (text[pos] != currentTag[i])
+                {
+                    return null;
+                }
+                pos++;
+            }
+
+            pos = SkipWhitespace(pos, text);
+
+            if (text.Length <= pos || text[pos] != '>')
+            {
+                return null;
+            }
+
+            return pos;
+        }
+
+        private static int SkipWhitespace(int pos, ReadOnlySpan<char> text)
+        {
+            for (; text.Length > pos; pos++)
+            {
+                if (!char.IsWhiteSpace(text[pos]))
+                {
+                    return pos;
+                }
+            }
+            return pos;
+        }
+    }
+}

--- a/AvaloniaVS.Shared/Completion/Manipulation/AvVSTextManipulator.cs
+++ b/AvaloniaVS.Shared/Completion/Manipulation/AvVSTextManipulator.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine;
+
+namespace AvaloniaVS.Shared.Completion.Manipulation
+{
+    public class AvVSTextManipulator
+    {
+        private readonly ReadOnlyMemory<char> _text;
+        private readonly int _position;
+        private readonly XmlParser _state;
+
+        public AvVSTextManipulator(string text, int position)
+        {
+            _position = position;
+            _text = text.AsMemory();
+
+            int parserStart = 0;
+            int parserEnd = 0;
+
+            // To improve performance parse only last tag
+            if (text.Length > 0)
+            {
+                // Findl last < tag
+                parserStart = position;
+                if (position >= text.Length)
+                {
+                    parserStart = text.Length - 1;
+                }
+                parserStart = text.LastIndexOf('<', parserStart);
+                if (parserStart < 0)
+                {
+                    parserStart = 0;
+                }
+
+
+                if (text.Length > position)
+                {
+                    parserEnd = position;
+                }
+                else
+                {
+                    parserEnd = text.Length;
+                }
+            }
+
+
+            _state = XmlParser.Parse(_text, parserStart, parserEnd);
+        }
+
+        public IList<TextManipulation> ManipulateText(ITextChange textChange)
+        {
+            List<TextManipulation> maniplations = new List<TextManipulation>();
+            if (_state.State == XmlParser.ParserState.StartElement
+                || (_state.State == XmlParser.ParserState.None && _text.Span[_state.ParserPos] == '>')
+                )
+            {
+                SynchronizeStartAndEndTag(textChange, maniplations);
+            }
+
+
+            if (_state.State == XmlParser.ParserState.StartElement
+            || _state.State == XmlParser.ParserState.AfterAttributeValue
+            || _state.State == XmlParser.ParserState.InsideElement)
+            {
+
+                new AvVSCloseXmlTagManipulation(_state, _text, _position).TryCloseTag(textChange, maniplations);
+            }
+
+            return maniplations.OrderByDescending(n => n.Start).ToList();
+        }
+
+        private char[] XmlNameSpecialCharacters = new[] { '-', '_', '.' };
+
+        private void SynchronizeStartAndEndTag(ITextChange textChange, List<TextManipulation> maniplations)
+        {
+            if (!textChange.NewText.All(n => char.IsLetterOrDigit(n) || XmlNameSpecialCharacters.Contains(n)))
+            {
+                return;
+            }
+
+            string startTag = _state.ParseCurrentTagName();
+            int? maybeTagStart = _state.CurrentValueStart;
+            if (maybeTagStart == null)
+            {
+                return;
+            }
+
+            int startPos = maybeTagStart.Value; // add 1 to take opening < into account
+            if (startTag.EndsWith("/"))
+            {
+                return; // start tag is self-closing
+            }
+            if (textChange.NewPosition < startPos || textChange.NewPosition > startPos + startTag.Length)
+            {
+                return; //we are not editing tag name
+            }
+
+            XmlParser searchEndTag = _state.Clone();
+            if (searchEndTag.SeekClosingTag())
+            {
+                string endTag = searchEndTag.ParseCurrentTagName();
+                if (endTag[0] != '/')
+                {
+                    return;
+                }
+
+                maybeTagStart = searchEndTag.CurrentValueStart;
+                if (maybeTagStart == null)
+                {
+                    return;
+                }
+
+                int endPos = maybeTagStart.Value; // add 1 to take opening < into account
+
+                // reverse change to start tag
+                startTag = textChange.ReverseOn(startTag, startPos);
+
+                bool isTheSameTag = endTag.Length > 0 && endTag.Substring(1) == startTag;
+                if (isTheSameTag)
+                {
+                    maniplations.AddRange(textChange.AsManipulations(endPos - startPos));
+                }
+            }
+        }
+    }
+}

--- a/AvaloniaVS.Shared/Completion/Metadata/AvVSDnLibMetadataProvider.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/AvVSDnLibMetadataProvider.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+using dnlib.DotNet;
+
+namespace AvaloniaVS.Shared.Completion.Metadata
+{
+    public class AvVSDnLibMetadataProvider : IMetadataProvider
+    {
+        public IMetadataReaderSession GetMetadata(IEnumerable<string> paths)
+        {
+            return new AvVSDnlibMetadataProviderSession(paths.ToArray());
+        }
+    }
+
+    public class AvVSDnlibMetadataProviderSession : IMetadataReaderSession
+    {
+        public IEnumerable<IAssemblyInformation> Assemblies { get; }
+
+        public AvVSDnlibMetadataProviderSession(string[] directoryPath)
+        {
+            Assemblies = LoadAssemblies(directoryPath).Select(a => new AssemblyWrapper(a)).ToList();
+        }
+
+        static List<AssemblyDef> LoadAssemblies(string[] lst)
+        {
+            AssemblyResolver asmResolver = new AssemblyResolver();
+            ModuleContext modCtx = new ModuleContext(asmResolver);
+            asmResolver.DefaultModuleContext = modCtx;
+            asmResolver.EnableTypeDefCache = true;
+
+            foreach (var path in lst)
+                asmResolver.PreSearchPaths.Add(path);
+
+            List<AssemblyDef> assemblies = new List<AssemblyDef>();
+
+            foreach (var asm in lst)
+            {
+                try
+                {
+                    var def = AssemblyDef.Load(File.ReadAllBytes(asm));
+                    def.Modules[0].Context = modCtx;
+                    asmResolver.AddToCache(def);
+                    assemblies.Add(def);
+                }
+                catch
+                {
+                    //Ignore
+                }
+            }
+
+            return assemblies;
+        }
+
+        public void Dispose()
+        {
+            //no-op
+        }
+    }
+
+    class AssemblyWrapper : IAvVSAssemblyInformation
+    {
+        private readonly AssemblyDef _asm;
+
+        public AssemblyWrapper(AssemblyDef asm)
+        {
+            _asm = asm;
+        }
+
+        public string Name => _asm.Name;
+
+        public IEnumerable<ITypeInformation> Types
+            => _asm.Modules.SelectMany(m => m.Types).Select(TypeWrapper.FromDef);
+
+        public IEnumerable<ICustomAttributeInformation> CustomAttributes
+            => _asm.CustomAttributes.Select(a => new CustomAttributeWrapper(a));
+
+        public IEnumerable<string> ManifestResourceNames
+            => _asm.ManifestModule.Resources.Select(r => r.Name.ToString());
+
+        public Stream GetManifestResourceStream(string name)
+            => _asm.ManifestModule.Resources.FindEmbeddedResource(name).CreateReader().AsStream();
+
+        public override string ToString() => Name;
+    }
+
+    class TypeWrapper : IAvVSTypeInformation
+    {
+        private readonly TypeDef _type;
+
+        public static TypeWrapper FromDef(TypeDef def) => def == null ? null : new TypeWrapper(def);
+
+        TypeWrapper(TypeDef type)
+        {
+            if (type == null)
+                throw new ArgumentNullException();
+            _type = type;
+        }
+
+        public string FullName => _type.FullName;
+
+        public string Name => _type.Name;
+
+        public string Namespace => _type.Namespace;
+
+        public ITypeInformation GetBaseType() => FromDef(_type.GetBaseType().ResolveTypeDef());
+
+
+        public IEnumerable<IEventInformation> Events => _type.Events.Select(e => new EventWrapper(e));
+
+        public IEnumerable<IMethodInformation> Methods => _type.Methods.Select(m => new MethodWrapper(m));
+
+        public IEnumerable<IFieldInformation> Fields => _type.Fields.Select(f => new FieldWrapper(f));
+
+        public IEnumerable<IPropertyInformation> Properties => _type.Properties
+            //Filter indexer properties
+            .Where(p =>
+                (p.GetMethod?.IsPublicOrInternal() == true && p.GetMethod.Parameters.Count == (p.GetMethod.IsStatic ? 0 : 1))
+                || (p.SetMethod?.IsPublicOrInternal() == true && p.SetMethod.Parameters.Count == (p.SetMethod.IsStatic ? 1 : 2)))
+            // Filter property overrides
+            .Where(p => !p.Name.Contains("."))
+            .Select(p => new PropertyWrapper(p));
+
+        public bool IsEnum => _type.IsEnum;
+
+        public bool IsStatic => _type.IsAbstract && _type.IsSealed;
+
+        public bool IsInterface => _type.IsInterface;
+
+        public bool IsPublic => _type.IsPublic;
+
+        public bool IsGeneric => _type.HasGenericParameters;
+
+        public IEnumerable<string> EnumValues
+        {
+            get
+            {
+                return _type.Fields.Where(f => f.IsStatic).Select(f => f.Name.String).ToArray();
+            }
+        }
+
+        public override string ToString() => Name;
+
+        public IEnumerable<ITypeInformation> NestedTypes =>
+            _type.HasNestedTypes ? _type.NestedTypes.Select(t => new TypeWrapper(t)) : Array.Empty<TypeWrapper>();
+    }
+
+    class CustomAttributeWrapper : ICustomAttributeInformation
+    {
+        private Lazy<IList<IAttributeConstructorArgumentInformation>> _args;
+        public CustomAttributeWrapper(CustomAttribute attr)
+        {
+            TypeFullName = attr.TypeFullName;
+            _args = new Lazy<IList<IAttributeConstructorArgumentInformation>>(() =>
+                attr.ConstructorArguments.Select(
+                    ca => (IAttributeConstructorArgumentInformation)
+                        new ConstructorArgumentWrapper(ca)).ToList());
+        }
+
+        public string TypeFullName { get; }
+
+        public IList<IAttributeConstructorArgumentInformation> ConstructorArguments => _args.Value;
+    }
+
+    class ConstructorArgumentWrapper : IAttributeConstructorArgumentInformation
+    {
+        public ConstructorArgumentWrapper(CAArgument ca)
+        {
+            Value = ca.Value;
+        }
+
+        public object Value { get; }
+    }
+
+    class PropertyWrapper : IAvVSPropertyInformation
+    {
+        public PropertyWrapper(PropertyDef prop)
+        {
+            Name = prop.Name;
+            var setMethod = prop.SetMethod;
+            var getMethod = prop.GetMethod;
+
+            IsStatic = setMethod?.IsStatic ?? getMethod?.IsStatic ?? false;
+
+            if (setMethod?.IsPublicOrInternal() == true)
+            {
+                HasPublicSetter = true;
+                TypeFullName = setMethod.Parameters[setMethod.IsStatic ? 0 : 1].Type.FullName;
+            }
+
+            if (getMethod?.IsPublicOrInternal() == true)
+            {
+                HasPublicGetter = true;
+                if (TypeFullName == null)
+                    TypeFullName = getMethod.ReturnType.FullName;
+            }
+        }
+
+        public bool IsStatic { get; }
+
+        public bool HasPublicSetter { get; }
+
+        public bool HasPublicGetter { get; }
+
+        public string TypeFullName { get; }
+
+        public string Name { get; }
+
+        public override string ToString() => Name;
+    }
+
+    class FieldWrapper : IAvVSFieldInformation
+    {
+        public FieldWrapper(FieldDef f)
+        {
+            IsStatic = f.IsStatic;
+            IsPublic = f.IsPublic || f.IsAssembly;
+            Name = f.Name;
+            ReturnTypeFullName = f.FieldType.FullName;
+
+            bool isRoutedEvent = false;
+            ITypeDefOrRef t = f.FieldType.ToTypeDefOrRef();
+            while (t != null)
+            {
+                if (t.Name == "RoutedEvent" && t.Namespace == "Avalonia.Interactivity")
+                {
+                    isRoutedEvent = true;
+                    break;
+                }
+                t = t.GetBaseType();
+            }
+
+            IsRoutedEvent = isRoutedEvent;
+        }
+
+        public bool IsRoutedEvent { get; }
+
+        public bool IsStatic { get; }
+
+        public bool IsPublic { get; }
+
+        public string Name { get; }
+
+        public string ReturnTypeFullName { get; }
+    }
+
+    class EventWrapper : IAvVSEventInformation
+    {
+        public EventWrapper(EventDef @event)
+        {
+            Name = @event.Name;
+            TypeFullName = @event.EventType.FullName;
+        }
+
+        public string Name { get; }
+
+        public string TypeFullName { get; }
+    }
+
+    class MethodWrapper : IAvVSMethodInformation
+    {
+        private readonly MethodDef _method;
+        private readonly Lazy<IList<IParameterInformation>> _parameters;
+
+        public MethodWrapper(MethodDef method)
+        {
+            _method = method;
+            _parameters = new Lazy<IList<IParameterInformation>>(() =>
+                _method.Parameters.Skip(_method.IsStatic ? 0 : 1).Select(p => (IParameterInformation)new ParameterWrapper(p)).ToList() as
+                    IList<IParameterInformation>);
+        }
+
+        public bool IsStatic => _method.IsStatic;
+
+        public bool IsPublic => _method.IsPublic;
+
+        public string Name => _method.Name;
+
+        public IList<IParameterInformation> Parameters => _parameters.Value;
+
+        public string ReturnTypeFullName => _method.ReturnType?.FullName;
+
+        public override string ToString() => Name;
+    }
+
+    class ParameterWrapper : IParameterInformation
+    {
+        private readonly Parameter _param;
+
+        public ParameterWrapper(Parameter param)
+        {
+            _param = param;
+        }
+
+        public string TypeFullName => _param.Type.FullName;
+    }
+
+    static class WrapperExtensions
+    {
+        public static bool IsPublicOrInternal(this MethodDef methodDef)
+                            => methodDef?.IsPublic == true || methodDef?.IsAssembly == true;
+    }
+}

--- a/AvaloniaVS.Shared/Completion/Metadata/AvVSDnLibMetadataProvider.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/AvVSDnLibMetadataProvider.cs
@@ -143,6 +143,34 @@ namespace AvaloniaVS.Shared.Completion.Metadata
 
         public override string ToString() => Name;
 
+        public IEnumerable<string> Pseudoclasses
+        {
+            get
+            {
+                // There is probably a much nicer way to do this, but it works
+                // Would be nice if we had a ref to the PseudoClassesAttribute to just pull
+                // the values from though...
+                var attr = _type.CustomAttributes
+                    .Where(x => x.TypeFullName.Contains("PseudoClassesAttribute"));
+
+                var selector = attr.Select(x =>
+                {
+                    if (x.HasConstructorArguments)
+                    {
+                        return (x.ConstructorArguments[0].Value as IEnumerable<CAArgument>)
+                                .Select(y => y.Value.ToString());
+                    }
+
+                    return Enumerable.Empty<string>();
+                });
+
+                foreach (var ret in selector)
+                    foreach (var ret2 in ret)
+                        yield return ret2;
+
+            }
+        }
+
         public IEnumerable<ITypeInformation> NestedTypes =>
             _type.HasNestedTypes ? _type.NestedTypes.Select(t => new TypeWrapper(t)) : Array.Empty<TypeWrapper>();
     }

--- a/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataConverter.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataConverter.cs
@@ -1,0 +1,717 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+using Avalonia.Ide.CompletionEngine;
+using System.Xml.Linq;
+using AvMetadata = Avalonia.Ide.CompletionEngine.Metadata;
+
+namespace AvaloniaVS.Shared.Completion.Metadata
+{
+    public static class AvVSMetadataConverter
+    {
+        internal static bool IsMarkupExtension(IAvVSTypeInformation type)
+        {
+            var def = type;
+
+            while (def != null)
+            {
+                if (def.Name == "MarkupExtension")
+                    return true;
+                def = (IAvVSTypeInformation)def.GetBaseType();
+            }
+
+            //in avalonia 0.9 there is no required base class, but convention only
+            if (type.FullName.EndsWith("Extension") && type.Methods.Any(m => m.Name == "ProvideValue"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static MetadataType ConvertTypeInfomation(IAvVSTypeInformation type)
+        {
+            var mt = new MetadataType
+            {
+                Name = type.Name,
+                FullName = type.FullName,
+                IsStatic = type.IsStatic,
+                IsMarkupExtension = IsMarkupExtension(type),
+                IsEnum = type.IsEnum,
+                HasHintValues = type.IsEnum,
+                IsGeneric = type.IsGeneric,
+            };
+            if (mt.IsEnum)
+                mt.HintValues = type.EnumValues.ToArray();
+            return mt;
+        }
+
+        private class AvaresInfo
+        {
+            public IAvVSAssemblyInformation Assembly;
+            public string ReturnTypeFullName;
+            public string LocalUrl;
+            public string GlobalUrl;
+
+            public override string ToString() => GlobalUrl;
+        }
+
+        public static AvMetadata ConvertMetadata(IMetadataReaderSession provider)
+        {
+            var types = new Dictionary<string, MetadataType>();
+            var typeDefs = new Dictionary<MetadataType, IAvVSTypeInformation>();
+            var metadata = new AvMetadata();
+            var resourceUrls = new List<string>();
+            var avaresValues = new List<AvaresInfo>();
+
+            var ignoredResExt = new[] { ".resources", ".rd.xml", "!AvaloniaResources" };
+
+            bool skipRes(string res) => ignoredResExt.Any(r => res.EndsWith(r, StringComparison.OrdinalIgnoreCase));
+
+            PreProcessTypes(types, metadata);
+
+            foreach (IAvVSAssemblyInformation asm in provider.Assemblies)
+            {
+                var aliases = new Dictionary<string, string[]>();
+
+                ProcessWellKnownAliases(asm, aliases);
+                ProcessCustomAttributes(asm, aliases);
+
+                var asmTypes = asm.Types.Cast<IAvVSTypeInformation>().ToArray();
+
+                foreach (IAvVSTypeInformation type in asmTypes.Where(x => !x.IsInterface && x.IsPublic))
+                {
+                    var mt = types[type.FullName] = ConvertTypeInfomation(type);
+                    typeDefs[mt] = type;
+                    metadata.AddType("clr-namespace:" + type.Namespace + ";assembly=" + asm.Name, mt);
+                    string[] nsAliases = null;
+                    string usingNamespace = $"using:{type.Namespace}";
+                    if (!aliases.TryGetValue(type.Namespace, out nsAliases))
+                    {
+                        nsAliases = new string[] { usingNamespace };
+                        aliases[type.Namespace] = nsAliases;
+                    }
+                    else if (!nsAliases.Contains(usingNamespace))
+                    {
+                        aliases[type.Namespace] = nsAliases.Union(new string[] { usingNamespace }).ToArray();
+                    }
+
+                    foreach (var alias in nsAliases)
+                        metadata.AddType(alias, mt);
+                }
+
+                ProcessAvaloniaResources(asm, asmTypes, avaresValues);
+
+                resourceUrls.AddRange(asm.ManifestResourceNames.Where(r => !skipRes(r)).Select(r => $"resm:{r}?assembly={asm.Name}"));
+            }
+
+            foreach (var type in types.Values)
+            {
+                IAvVSTypeInformation typeDef;
+                typeDefs.TryGetValue(type, out typeDef);
+
+                var ctors = typeDef?.Methods
+                    .Where(m => m.IsPublic && !m.IsStatic && m.Name == ".ctor" && m.Parameters.Count == 1);
+
+                if (typeDef?.IsEnum ?? false)
+                {
+                    foreach (var value in typeDef.EnumValues)
+                    {
+                        var p = new MetadataProperty(value, type, type, false, true, true, false);
+
+                        type.Properties.Add(p);
+                    }
+                }
+
+                int level = 0;
+                while (typeDef != null)
+                {
+                    var currentType = types.GetValueOrDefault(typeDef.FullName);
+                    foreach (var prop in typeDef.Properties)
+                    {
+                        if (!prop.HasPublicGetter && !prop.HasPublicSetter)
+                            continue;
+
+                        var p = new MetadataProperty(prop.Name, types.GetValueOrDefault(prop.TypeFullName),
+                            currentType, false, prop.IsStatic, prop.HasPublicGetter,
+                            prop.HasPublicSetter);
+
+                        type.Properties.Add(p);
+                    }
+
+                    foreach (var eventDef in typeDef.Events)
+                    {
+                        var e = new MetadataEvent(eventDef.Name, types.GetValueOrDefault(eventDef.TypeFullName),
+                            types.GetValueOrDefault(typeDef.FullName), false);
+
+                        type.Events.Add(e);
+                    }
+
+                    //check for attached properties only on top level
+                    if (level == 0)
+                    {
+                        foreach (var methodDef in typeDef.Methods)
+                        {
+                            if (methodDef.Name.StartsWith("Set", StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
+                                && methodDef.Parameters.Count == 2)
+                            {
+                                var name = methodDef.Name.Substring(3);
+                                type.Properties.Add(new MetadataProperty(name,
+                                    types.GetValueOrDefault(methodDef.Parameters[1].TypeFullName),
+                                    types.GetValueOrDefault(typeDef.FullName),
+                                    true, false, true, true));
+                            }
+                        }
+
+                        foreach (var fieldDef in typeDef.Fields)
+                        {
+                            if (fieldDef.IsStatic && fieldDef.IsPublic)
+                            {
+                                if ((fieldDef.IsRoutedEvent || fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    var name = fieldDef.Name;
+                                    if (fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        name = name.Substring(0, name.Length - "Event".Length);
+                                    }
+
+                                    type.Events.Add(new MetadataEvent(name,
+                                        types.GetValueOrDefault(fieldDef.ReturnTypeFullName),
+                                        types.GetValueOrDefault(typeDef.FullName),
+                                        true));
+                                }
+                                else if (type.IsStatic)
+                                {
+                                    type.Properties.Add(new MetadataProperty(fieldDef.Name, null, type, false, true, true, false));
+                                }
+                            }
+                        }
+                    }
+
+                    if (typeDef.FullName == "Avalonia.AvaloniaObject")
+                    {
+                        type.IsAvaloniaObjectType = true;
+                    }
+
+                    typeDef = (IAvVSTypeInformation)typeDef.GetBaseType();
+                    level++;
+                }
+
+                type.HasAttachedProperties = type.Properties.Any(p => p.IsAttached);
+                type.HasAttachedEvents = type.Events.Any(e => e.IsAttached);
+                type.HasStaticGetProperties = type.Properties.Any(p => p.IsStatic && p.HasGetter);
+                type.HasSetProperties = type.Properties.Any(p => !p.IsStatic && p.HasSetter);
+
+                if (ctors?.Any() == true)
+                {
+                    bool supportType = ctors.Any(m => m.Parameters[0].TypeFullName == "System.Type");
+                    bool supportObject = ctors.Any(m => m.Parameters[0].TypeFullName == "System.Object" ||
+                                                        m.Parameters[0].TypeFullName == "System.String");
+
+                    if (types.TryGetValue(ctors.First().Parameters[0].TypeFullName, out MetadataType parType)
+                            && parType.HasHintValues)
+                    {
+                        type.SupportCtorArgument = MetadataTypeCtorArgument.HintValues;
+                        type.HasHintValues = true;
+                        type.HintValues = parType.HintValues;
+                    }
+                    else if (supportType && supportObject)
+                        type.SupportCtorArgument = MetadataTypeCtorArgument.TypeAndObject;
+                    else if (supportType)
+                        type.SupportCtorArgument = MetadataTypeCtorArgument.Type;
+                    else if (supportObject)
+                        type.SupportCtorArgument = MetadataTypeCtorArgument.Object;
+                }
+            }
+
+            PostProcessTypes(types, metadata, resourceUrls, avaresValues);
+
+            return metadata;
+        }
+
+        private static void ProcessAvaloniaResources(IAvVSAssemblyInformation asm, 
+            IAvVSTypeInformation[] asmTypes, List<AvaresInfo> avaresValues)
+        {
+            const string avaresToken = "Build:"; //or "Populate:" should work both ways
+
+            void registeravares(string localUrl, string returnTypeFullName = "")
+            {
+                var globalUrl = $"avares://{asm.Name}{localUrl}";
+
+                if (!avaresValues.Any(v => v.GlobalUrl == globalUrl))
+                {
+                    var avres = new AvaresInfo
+                    {
+                        Assembly = asm,
+                        LocalUrl = localUrl,
+                        GlobalUrl = globalUrl,
+                        ReturnTypeFullName = returnTypeFullName
+                    };
+
+                    avaresValues.Add(avres);
+                }
+            }
+
+            var resType = asmTypes.FirstOrDefault(t => t.FullName == "CompiledAvaloniaXaml.!AvaloniaResources");
+            if (resType != null)
+            {
+                foreach (var res in resType.Methods.Where(m => m.Name.StartsWith(avaresToken)))
+                {
+                    registeravares(res.Name.Replace(avaresToken, ""), res.ReturnTypeFullName ?? "");
+                }
+            }
+
+            //try add avares Embedded resources like image,stream and x:Class
+            if (asm.ManifestResourceNames.Contains("!AvaloniaResources"))
+            {
+                try
+                {
+                    using (var avaresStream = asm.GetManifestResourceStream("!AvaloniaResources"))
+                    using (var r = new BinaryReader(avaresStream))
+                    {
+                        var ms = new MemoryStream(r.ReadBytes(r.ReadInt32()));
+                        var br = new BinaryReader(ms);
+
+                        int version = br.ReadInt32();
+                        if (version == 1)
+                        {
+                            var assetDoc = XDocument.Load(ms);
+                            var ns = assetDoc.Root.GetDefaultNamespace();
+                            var avaResEntries = assetDoc.Root.Element(ns.GetName("Entries")).Elements(ns.GetName("AvaloniaResourcesIndexEntry"))
+                                .Select(entry => new
+                                {
+                                    Path = entry.Element(ns.GetName("Path")).Value,
+                                    Offset = int.Parse(entry.Element(ns.GetName("Offset")).Value),
+                                    Size = int.Parse(entry.Element(ns.GetName("Size")).Value)
+                                }).ToArray();
+
+                            var xClassEntries = avaResEntries.FirstOrDefault(v => v.Path == "/!AvaloniaResourceXamlInfo");
+
+                            //get information about x:Class resources
+                            if (xClassEntries != null && xClassEntries.Size > 0)
+                            {
+                                try
+                                {
+                                    avaresStream.Seek(xClassEntries.Offset, SeekOrigin.Current);
+                                    var xClassDoc = XDocument.Load(new MemoryStream(r.ReadBytes(xClassEntries.Size)));
+                                    var xClassMappingNode = xClassDoc.Root.Element(xClassDoc.Root.GetDefaultNamespace().GetName("ClassToResourcePathIndex"));
+                                    if (xClassMappingNode != null)
+                                    {
+                                        const string arraysNs = "http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+                                        var keyvalueofss = XName.Get("KeyValueOfstringstring", arraysNs);
+                                        var keyName = XName.Get("Key", arraysNs);
+                                        var valueName = XName.Get("Value", arraysNs);
+
+                                        var xClassMappings = xClassMappingNode.Elements(keyvalueofss)
+                                                        .Where(e => e.Elements(keyName).Any() && e.Elements(valueName).Any())
+                                                        .Select(e => new
+                                                        {
+                                                            Type = e.Element(keyName).Value,
+                                                            Path = e.Element(valueName).Value,
+                                                        }).ToArray();
+
+                                        foreach (var xcm in xClassMappings)
+                                        {
+                                            var resultType = asmTypes.FirstOrDefault(t => t.FullName == xcm.Type);
+                                            //if we need another check
+                                            //if (resultType?.Methods?.Any(m => m.Name == "!XamlIlPopulate") ?? false)
+                                            if (resultType != null)
+                                            {
+                                                //we set here base class like Style, Styles, UserControl so we can manage
+                                                //resources in a common way later
+                                                registeravares(xcm.Path, resultType.GetBaseType()?.FullName ?? "");
+                                            }
+                                        }
+                                    }
+                                }
+                                catch (Exception xClassEx)
+                                {
+                                    Console.WriteLine($"Failed fetch avalonia x:class resources in {asm.Name}, {xClassEx.Message}");
+                                }
+                            }
+
+                            //add other img/stream resources
+                            foreach (var entry in avaResEntries.Where(v => !v.Path.StartsWith("/!")))
+                            {
+                                registeravares(entry.Path);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed fetch avalonia resources in {asm.Name}, {ex.Message}");
+                }
+            }
+        }
+
+        private static void ProcessCustomAttributes(IAvVSAssemblyInformation asm, Dictionary<string, string[]> aliases)
+        {
+            foreach (
+                var attr in
+                asm.CustomAttributes.Where(a => a.TypeFullName == "Avalonia.Metadata.XmlnsDefinitionAttribute" ||
+                                                a.TypeFullName == "Portable.Xaml.Markup.XmlnsDefinitionAttribute"))
+            {
+                var ns = attr.ConstructorArguments[1].Value.ToString();
+                var current = new[] { attr.ConstructorArguments[0].Value.ToString() };
+                string[] allns = null;
+
+                if (aliases.TryGetValue(ns, out allns))
+                    allns = allns.Union(current).Distinct().ToArray();
+
+                aliases[ns] = allns ?? current;
+            }
+        }
+
+        private static void ProcessWellKnownAliases(IAvVSAssemblyInformation asm, Dictionary<string, string[]> aliases)
+        {
+            //look like we don't have xmlns for avalonia.layout TODO: add it in avalonia
+            //may be don 't remove it for avalonia 0.7 or below for support completion for layout enums etc.
+            aliases["Avalonia.Layout"] = new[] { "https://github.com/avaloniaui" };
+        }
+
+        private static void PreProcessTypes(Dictionary<string, MetadataType> types, AvMetadata metadata)
+        {
+            MetadataType xDataType, xCompiledBindings, boolType, typeType;
+            var toAdd = new List<MetadataType>
+            {
+                (boolType = new MetadataType()
+                {
+                    Name = typeof(bool).FullName,
+                    HasHintValues = true,
+                    HintValues = new[] { "True", "False" }
+                }),
+                new MetadataType(){ Name = typeof(System.Uri).FullName },
+                (typeType = new MetadataType(){ Name = typeof(System.Type).FullName }),
+                new MetadataType(){ Name = "Avalonia.Media.IBrush" },
+                new MetadataType(){ Name = "Avalonia.Media.Imaging.IBitmap" },
+                new MetadataType(){ Name = "Avalonia.Media.IImage" },
+            };
+
+            foreach (var t in toAdd)
+                types.Add(t.Name, t);
+
+            var portableXamlExtTypes = new[]
+            {
+                new MetadataType()
+                {
+                    Name = "StaticExtension",
+                    SupportCtorArgument = MetadataTypeCtorArgument.Object,
+                    HasSetProperties = true,
+                    IsMarkupExtension = true,
+                },
+                new MetadataType()
+                {
+                    Name = "TypeExtension",
+                    SupportCtorArgument = MetadataTypeCtorArgument.TypeAndObject,
+                    HasSetProperties = true,
+                    IsMarkupExtension = true,
+                },
+                new MetadataType()
+                {
+                    Name = "NullExtension",
+                    HasSetProperties = true,
+                    IsMarkupExtension = true,
+                },
+                new MetadataType()
+                {
+                    Name = "Class",
+                    IsXamlDirective = true
+                },
+                new MetadataType()
+                {
+                    Name = "Name",
+                    IsXamlDirective = true
+                },
+                new MetadataType()
+                {
+                    Name = "Key",
+                    IsXamlDirective = true
+                },
+                xDataType = new MetadataType()
+                {
+                    Name = "DataType",
+                    IsXamlDirective = true,
+                    Properties = { new MetadataProperty("", typeType,null, false, false, false, true)},
+                },
+                xCompiledBindings = new MetadataType()
+                {
+                    Name = "CompileBindings",
+                    IsXamlDirective = true,
+                    Properties = { new MetadataProperty("", boolType,null, false, false, false, true)},
+                },
+            };
+
+            //as in avalonia 0.9 Portablexaml is missing we need to hardcode some extensions
+            foreach (var t in portableXamlExtTypes)
+            {
+                metadata.AddType(MetadataUtils.Xaml2006Namespace, t);
+            }
+
+            types.Add(xDataType.Name, xDataType);
+            types.Add(xCompiledBindings.Name, xCompiledBindings);
+
+            metadata.AddType("", new MetadataType() { Name = "xmlns", IsXamlDirective = true });
+        }
+
+        private static void PostProcessTypes(Dictionary<string, MetadataType> types, 
+            AvMetadata metadata, IEnumerable<string> resourceUrls, List<AvaresInfo> avaResValues)
+        {
+            bool rhasext(string resource, string ext) => resource.StartsWith("resm:") ? 
+                resource.Contains(ext + "?assembly=") : resource.EndsWith(ext);
+
+            var allresourceUrls = avaResValues.Select(v => v.GlobalUrl).Concat(resourceUrls).ToArray();
+
+            var resType = new MetadataType()
+            {
+                Name = "avares://,resm:",
+                IsStatic = true,
+                HasHintValues = true,
+                HintValues = allresourceUrls
+            };
+
+            types.Add(resType.Name, resType);
+
+            var xamlResType = new MetadataType()
+            {
+                Name = "avares://*.xaml,resm:*.xaml",
+                HasHintValues = true,
+                HintValues = resType.HintValues.Where(r => rhasext(r, ".xaml") || rhasext(r, ".paml") || rhasext(r, ".axaml")).ToArray()
+            };
+
+            var styleResType = new MetadataType()
+            {
+                Name = "Style avares://*.xaml,resm:*.xaml",
+                HasHintValues = true,
+                HintValues = avaResValues.Where(v => v.ReturnTypeFullName.StartsWith("Avalonia.Styling.Style"))
+                                        .Select(v => v.GlobalUrl)
+                                        .Concat(resourceUrls.Where(r => rhasext(r, ".xaml") || rhasext(r, ".paml") || rhasext(r, ".axaml")))
+                                        .ToArray()
+            };
+
+            types.Add(styleResType.Name, styleResType);
+
+            IEnumerable<string> filterLocalRes(MetadataType type, string currentAssemblyName)
+            {
+                var localResPrefix = $"avares://{currentAssemblyName}";
+                var resmSuffix = $"?assembly={currentAssemblyName}";
+
+                foreach (var hint in type.HintValues ?? Array.Empty<string>())
+                {
+                    if (hint.StartsWith("avares://"))
+                    {
+                        if (hint.StartsWith(localResPrefix))
+                        {
+                            yield return hint.Substring(localResPrefix.Length);
+                        }
+                    }
+                    else if (hint.StartsWith("resm:"))
+                    {
+                        if (hint.EndsWith(resmSuffix))
+                        {
+                            yield return hint.Substring(0, hint.Length - resmSuffix.Length);
+                        }
+                    }
+                }
+            }
+
+            resType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(xamlResType, a);
+            xamlResType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(xamlResType, a);
+            styleResType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(styleResType, a);
+
+            types.Add(xamlResType.Name, xamlResType);
+
+            var allProps = new Dictionary<string, MetadataProperty>();
+
+            foreach (var type in types.Where(t => t.Value.IsAvaloniaObjectType))
+            {
+                foreach (var v in type.Value.Properties.Where(p => p.HasSetter && p.HasGetter))
+                {
+                    allProps[v.Name] = v;
+                }
+            }
+
+            string[] allAvaloniaProps = allProps.Keys.ToArray();
+
+            if (!types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension", out MetadataType bindingExtType))
+            {
+                if (types.TryGetValue("Avalonia.Data.Binding", out MetadataType origBindingType))
+                {
+                    //avalonia 0.10 has implicit binding extension
+                    bindingExtType = origBindingType.CloneAs("BindingExtension",
+                        "Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension");
+                    bindingExtType.IsMarkupExtension = true;
+
+                    types.Add(bindingExtType.FullName, bindingExtType);
+                    metadata.AddType(MetadataUtils.AvaloniaNamespace, bindingExtType);
+                }
+            }
+
+            types.TryGetValue("Avalonia.Controls.Control", out MetadataType controlType);
+            types.TryGetValue(typeof(Type).FullName, out MetadataType typeType);
+
+            var dataContextType = new MetadataType()
+            {
+                Name = "{BindingPath}",
+                FullName = "{BindingPath}",
+                HasHintValues = true,
+                HintValues = new[] { "$parent", "$parent[", "$self" },
+            };
+
+            //bindings related hints
+            if (types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension", out MetadataType bindingType))
+            {
+                bindingType.SupportCtorArgument = MetadataTypeCtorArgument.None;
+                var pathProp = bindingType.Properties.FirstOrDefault(p => p.Name == "Path");
+                if (pathProp != null)
+                    pathProp.Type = dataContextType;
+
+                bindingType.Properties.Add(new MetadataProperty("", dataContextType, bindingType, false, false, true, true));
+            }
+
+            if (types.TryGetValue("Avalonia.Data.TemplateBinding", out MetadataType templBinding))
+            {
+                var tbext = new MetadataType()
+                {
+                    Name = "TemplateBindingExtension",
+                    IsMarkupExtension = true,
+                    Properties = templBinding.Properties,
+                    SupportCtorArgument = MetadataTypeCtorArgument.HintValues,
+                    HasHintValues = allAvaloniaProps?.Any() ?? false,
+                    HintValues = allAvaloniaProps
+                };
+
+                types["TemplateBindingExtension"] = tbext;
+                metadata.AddType(MetadataUtils.AvaloniaNamespace, tbext);
+            }
+
+            if (types.TryGetValue("Portable.Xaml.Markup.TypeExtension", out MetadataType typeExtension))
+            {
+                typeExtension.SupportCtorArgument = MetadataTypeCtorArgument.Type;
+            }
+
+            //TODO: may be make it to load from assembly resources
+            string[] commonResKeys = new string[] {
+//common brushes
+"ThemeBackgroundBrush","ThemeBorderLowBrush","ThemeBorderMidBrush","ThemeBorderHighBrush",
+"ThemeControlLowBrush","ThemeControlMidBrush","ThemeControlHighBrush",
+"ThemeControlHighlightLowBrush","ThemeControlHighlightMidBrush","ThemeControlHighlightHighBrush",
+"ThemeForegroundBrush","ThemeForegroundLowBrush","HighlightBrush",
+"ThemeAccentBrush","ThemeAccentBrush2","ThemeAccentBrush3","ThemeAccentBrush4",
+"ErrorBrush","ErrorLowBrush",
+//some other usefull
+"ThemeBorderThickness", "ThemeDisabledOpacity",
+"FontSizeSmall","FontSizeNormal","FontSizeLarge"
+                };
+
+            if (types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.DynamicResourceExtension", out MetadataType dynRes))
+            {
+                dynRes.SupportCtorArgument = MetadataTypeCtorArgument.HintValues;
+                dynRes.HasHintValues = true;
+                dynRes.HintValues = commonResKeys;
+            }
+
+            if (types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.StaticResourceExtension", out MetadataType stRes))
+            {
+                stRes.SupportCtorArgument = MetadataTypeCtorArgument.HintValues;
+                stRes.HasHintValues = true;
+                stRes.HintValues = commonResKeys;
+            }
+
+            //brushes
+            if (types.TryGetValue("Avalonia.Media.IBrush", out MetadataType brushType) &&
+                types.TryGetValue("Avalonia.Media.Brushes", out MetadataType brushes))
+            {
+                brushType.HasHintValues = true;
+                brushType.HintValues = brushes.Properties.Where(p => p.IsStatic && p.HasGetter).Select(p => p.Name).ToArray();
+            }
+
+            if (types.TryGetValue("Avalonia.Styling.Selector", out MetadataType styleSelector))
+            {
+                styleSelector.HasHintValues = true;
+                styleSelector.IsCompositeValue = true;
+
+                List<string> hints = new List<string>();
+
+                //some reserved words
+                hints.AddRange(new[] { "/template/", ":is()", ">", "#", "." });
+
+                //some pseudo classes
+                hints.AddRange(new[]
+                {
+                    ":pointerover", ":pressed", ":disabled", ":focus",
+                    ":selected", ":vertical", ":horizontal",
+                    ":checked", ":unchecked", ":indeterminate"
+                });
+
+                hints.AddRange(types.Where(t => t.Value.IsAvaloniaObjectType).Select(t => t.Value.Name.Replace(":", "|")));
+
+                styleSelector.HintValues = hints.ToArray();
+            }
+
+            string[] bitmaptypes = new[] { ".jpg", ".bmp", ".png", ".ico" };
+
+            bool isbitmaptype(string resource) => bitmaptypes.Any(ext => rhasext(resource, ext));
+
+            if (types.TryGetValue("Avalonia.Media.Imaging.IBitmap", out MetadataType ibitmapType))
+            {
+                ibitmapType.HasHintValues = true;
+                ibitmapType.HintValues = allresourceUrls.Where(r => isbitmaptype(r)).ToArray();
+                ibitmapType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(ibitmapType, a);
+            }
+
+            if (types.TryGetValue("Avalonia.Media.IImage", out MetadataType iImageType))
+            {
+                iImageType.HasHintValues = true;
+                iImageType.HintValues = allresourceUrls.Where(r => isbitmaptype(r)).ToArray();
+                iImageType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(ibitmapType, a);
+            }
+
+            if (types.TryGetValue("Avalonia.Controls.WindowIcon", out MetadataType winIcon))
+            {
+                winIcon.HasHintValues = true;
+                winIcon.HintValues = allresourceUrls.Where(r => rhasext(r, ".ico")).ToArray();
+                winIcon.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(winIcon, a);
+            }
+
+            if (types.TryGetValue("Avalonia.Markup.Xaml.Styling.StyleInclude", out MetadataType styleIncludeType))
+            {
+                var source = styleIncludeType.Properties.FirstOrDefault(p => p.Name == "Source");
+
+                if (source != null)
+                    source.Type = styleResType;
+            }
+
+            if (types.TryGetValue("Avalonia.Markup.Xaml.Styling.StyleIncludeExtension", out MetadataType styleIncludeExtType))
+            {
+                var source = styleIncludeExtType.Properties.FirstOrDefault(p => p.Name == "Source");
+
+                if (source != null)
+                    source.Type = xamlResType;
+            }
+
+            if (types.TryGetValue(typeof(Uri).FullName, out MetadataType uriType))
+            {
+                uriType.HasHintValues = true;
+                uriType.HintValues = allresourceUrls.ToArray();
+                uriType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(uriType, a);
+            }
+
+            if (typeType != null)
+            {
+                var typeArguments = new MetadataType()
+                {
+                    Name = "TypeArguments",
+                    IsXamlDirective = true,
+                    IsValidForXamlContextFunc = (a, t, p) => t?.IsGeneric == true,
+                    Properties = { new MetadataProperty("", typeType, null, false, false, false, true) }
+                };
+
+                metadata.AddType(MetadataUtils.Xaml2006Namespace, typeArguments);
+            }
+        }
+    }
+}

--- a/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataConverter.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataConverter.cs
@@ -66,6 +66,7 @@ namespace AvaloniaVS.Shared.Completion.Metadata
             var metadata = new AvMetadata();
             var resourceUrls = new List<string>();
             var avaresValues = new List<AvaresInfo>();
+            var pseudoclasses = new HashSet<string>();
 
             var ignoredResExt = new[] { ".resources", ".rd.xml", "!AvaloniaResources" };
 
@@ -129,6 +130,13 @@ namespace AvaloniaVS.Shared.Completion.Metadata
                 int level = 0;
                 while (typeDef != null)
                 {
+                    var typePseudoclasses = typeDef.Pseudoclasses;
+
+                    foreach (var pc in typePseudoclasses)
+                    {
+                        pseudoclasses.Add(pc);
+                    }
+
                     var currentType = types.GetValueOrDefault(typeDef.FullName);
                     foreach (var prop in typeDef.Properties)
                     {
@@ -227,7 +235,7 @@ namespace AvaloniaVS.Shared.Completion.Metadata
                 }
             }
 
-            PostProcessTypes(types, metadata, resourceUrls, avaresValues);
+            PostProcessTypes(types, metadata, resourceUrls, avaresValues, pseudoclasses);
 
             return metadata;
         }
@@ -458,7 +466,8 @@ namespace AvaloniaVS.Shared.Completion.Metadata
         }
 
         private static void PostProcessTypes(Dictionary<string, MetadataType> types, 
-            AvMetadata metadata, IEnumerable<string> resourceUrls, List<AvaresInfo> avaResValues)
+            AvMetadata metadata, IEnumerable<string> resourceUrls, List<AvaresInfo> avaResValues,
+            HashSet<string> pseudoclasses)
         {
             bool rhasext(string resource, string ext) => resource.StartsWith("resm:") ? 
                 resource.Contains(ext + "?assembly=") : resource.EndsWith(ext);
@@ -637,15 +646,9 @@ namespace AvaloniaVS.Shared.Completion.Metadata
                 List<string> hints = new List<string>();
 
                 //some reserved words
-                hints.AddRange(new[] { "/template/", ":is()", ">", "#", "." });
+                hints.AddRange(new[] { "/template/", ":is()", ">", "#", ".", "^", ":not()" });
 
-                //some pseudo classes
-                hints.AddRange(new[]
-                {
-                    ":pointerover", ":pressed", ":disabled", ":focus",
-                    ":selected", ":vertical", ":horizontal",
-                    ":checked", ":unchecked", ":indeterminate"
-                });
+                hints.AddRange(pseudoclasses);
 
                 hints.AddRange(types.Where(t => t.Value.IsAvaloniaObjectType).Select(t => t.Value.Name.Replace(":", "|")));
 

--- a/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataReader.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/AvVSMetadataReader.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+using AvMetadata = Avalonia.Ide.CompletionEngine.Metadata;
+
+namespace AvaloniaVS.Shared.Completion.Metadata
+{
+    public class AvVSMetadataReader
+    {
+        private readonly AvVSDnLibMetadataProvider _provider;
+
+        public AvVSMetadataReader()
+        {
+            _provider = new AvVSDnLibMetadataProvider();
+        }
+
+        IEnumerable<string> GetAssemblies(string path)
+        {
+            var depsPath = Path.Combine(Path.GetDirectoryName(path),
+                Path.GetFileNameWithoutExtension(path) + ".deps.json");
+            if (File.Exists(depsPath))
+                return DepsJsonAssemblyListLoader.ParseFile(depsPath);
+            return Directory.GetFiles(Path.GetDirectoryName(path)).Where(f => f.EndsWith(".dll") || f.EndsWith(".exe"));
+        }
+
+        public AvMetadata GetForTargetAssembly(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+
+            using (var session = _provider.GetMetadata(GetAssemblies(path)))
+                return AvVSMetadataConverter.ConvertMetadata(session);
+        }
+    }
+}

--- a/AvaloniaVS.Shared/Completion/Metadata/MetadataUtils.cs
+++ b/AvaloniaVS.Shared/Completion/Metadata/MetadataUtils.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+
+namespace AvaloniaVS.Shared.Completion.Metadata
+{
+    public static class MetadataUtils
+    {
+        private static readonly XmlReaderSettings XmlSettings = new XmlReaderSettings()
+        {
+            DtdProcessing = DtdProcessing.Ignore,
+        };
+
+        public static bool CheckAvaloniaRoot(string content)
+        {
+            return CheckAvaloniaRoot(XmlReader.Create(new StringReader(content), XmlSettings));
+        }
+
+        public static bool CheckAvaloniaRoot(XmlReader reader)
+        {
+            try
+            {
+                while (!reader.IsStartElement())
+                {
+                    reader.Read();
+                }
+                if (!reader.MoveToFirstAttribute())
+                    return false;
+                do
+                {
+                    if (reader.Name == "xmlns")
+                    {
+                        reader.ReadAttributeValue();
+                        return reader.Value.ToLower() == AvaloniaNamespace;
+                    }
+
+                } while (reader.MoveToNextAttribute());
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public const string AvaloniaNamespace = "https://github.com/avaloniaui";
+        public const string Xaml2006Namespace = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+        public static TValue GetOrCreate<TKey, TValue>(this Dictionary<TKey, TValue> dic, TKey key,
+            Func<TKey, TValue> getter)
+        {
+            TValue rv;
+            if (!dic.TryGetValue(key, out rv))
+                dic[key] = rv = getter(key);
+            return rv;
+        }
+
+        public static TValue GetOrCreate<TKey, TValue>(this Dictionary<TKey, TValue> dic, TKey key) where TValue : new()
+        {
+            TValue rv;
+            if (!dic.TryGetValue(key, out rv))
+                dic[key] = rv = new TValue();
+            return rv;
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dic, TKey key)
+        {
+            TValue rv;
+            if (!dic.TryGetValue(key, out rv))
+                return default(TValue);
+            return rv;
+        }
+    }
+}

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Avalonia.Ide.CompletionEngine;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -106,7 +106,7 @@ namespace AvaloniaVS.IntelliSense
                     // the previous completion session and start a new one starting at the ':'
                     // Otherwise typing 'Control:' won't show the intellisense popup with the
                     // pseudoclasses until after you start typing a pseudoclass
-                    if (c == ':')
+                    if (c == ':' || c == '.')
                     {
                         _session.Dismiss();
                         return HandleSessionStart(c);
@@ -151,7 +151,9 @@ namespace AvaloniaVS.IntelliSense
 
                         // If the spacebar is used to complete then it should be entered into the
                         // buffer, all other chars should be swallowed.
-                        var skip = c != ' ';
+                        // Don't swallow '.' either, otherwise it will require two presses of the '.' key
+                        // for something like 'Window.Resources'
+                        var skip = c != ' ' && c != '.';
 
                         _session.Commit();
 

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -120,7 +120,7 @@ namespace AvaloniaVS.IntelliSense
                             var state = XmlParser.Parse(_textView.TextSnapshot.GetText().AsMemory(),
                                 0, pos.BufferPosition.Position);
 
-                            if (!state.AttributeName.Equals("Selector"))
+                            if (!state?.AttributeName?.Equals("Selector") == true)
                             {
                                 _session?.Filter();
                                 return false;

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -196,8 +196,38 @@ namespace AvaloniaVS.IntelliSense
             {
                 return false;
             }
-            
-            _session = _completionBroker.CreateCompletionSession(
+
+            // When adding an xmlns definition, we were getting 2 intellisense popups because (I think)
+            // the VS XML intellisense handler was popping one up and then we are creating our own session
+            // here. It turns out one of the completionsets though is an Avalonia one, so if a session already
+            // exists and one of the CompletionSets is from Avalonia, use that session instead of creating
+            // a new one - and we won't get the double popup
+            ICompletionSession existingSession = null;
+            var sessions = _completionBroker.GetSessions(_textView);
+            if (sessions.Count > 0)
+            {
+                for (int i = sessions.Count - 1; i >= 0; i--)
+                {
+                    if (sessions[i].CompletionSets.Count == 0)
+                        sessions[i].Dismiss();
+
+                    var sets = sessions[i].CompletionSets;
+
+                    for (int j = sets.Count - 1; j >= 0; j--)
+                    {
+                        if (sets[j].Moniker.Equals("Avalonia"))
+                        {
+                            existingSession = sessions[i];
+                            break;
+                        }
+                    }
+
+                    if (existingSession != null)
+                        break;
+                }
+            }
+
+            _session = existingSession ?? _completionBroker.CreateCompletionSession(
                 _textView,
                 caretPoint?.Snapshot.CreateTrackingPoint(caretPoint.Value.Position, PointTrackingMode.Positive),
                 true);

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
@@ -38,15 +38,42 @@ namespace AvaloniaVS.IntelliSense
                 if (completions?.Completions.Count > 0)
                 {
                     var start = completions.StartPosition;
+
+                    // pseudoclasses should only be returned in a Selector, so this is an easy filter
+                    // We need to offset the start though for pseudoclasses to remove what they're 
+                    // attached to: Control:pointerover -> :pointerover
+                    if (completions.Completions[0].DisplayText.StartsWith(":"))
+                    {
+                        for (int i = pos - 1; i >= 0; i--)
+                        {
+                            if (char.IsWhiteSpace(text[i]) || text[i] == ':')
+                            {
+                                start = i;
+                                break;
+                            }
+                        }
+                    }
+
                     var span = new SnapshotSpan(pos.Snapshot, start, pos.Position - start);
                     var applicableTo = pos.Snapshot.CreateTrackingSpan(span, SpanTrackingMode.EdgeInclusive);
-
+                    
                     completionSets.Insert(0, new CompletionSet(
                         "Avalonia",
                         "Avalonia",
                         applicableTo,
                         XamlCompletion.Create(completions.Completions, _imageService),
                         null));
+
+                    // This selects the first item in the completion popup - otherwise you have to physically
+                    // interact with the completion list (either via mouse or keyboard arrows) otherwise tab
+                    // or space won't trigger it
+                    // TODO: We should really try to find the best match of the completion list and select that
+                    // instead, but that's more than I want to do right now
+                    if (completions.Completions.Count > 0)
+                    {
+                        completionSets[0].SelectionStatus = new CompletionSelectionStatus(
+                            completionSets[0].Completions[0], true, false);
+                    }
 
                     string completionHint = completions.Completions.Count == 0 ?
                         "no completions found" :

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using AvaloniaVS.Models;
+using AvaloniaVS.Shared.Completion;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Serilog;
-using CompletionEngine = Avalonia.Ide.CompletionEngine.CompletionEngine;
 
 namespace AvaloniaVS.IntelliSense
 {
@@ -15,13 +15,13 @@ namespace AvaloniaVS.IntelliSense
     {
         private readonly ITextBuffer _buffer;
         private readonly IVsImageService2 _imageService;
-        private readonly CompletionEngine _engine;
+        private readonly AvVSCompletionEngine _engine;
 
         public XamlCompletionSource(ITextBuffer textBuffer, IVsImageService2 imageService)
         {
             _buffer = textBuffer;
             _imageService = imageService;
-            _engine = new CompletionEngine();
+            _engine = new AvVSCompletionEngine();
         }
 
         public void AugmentCompletionSession(ICompletionSession session, IList<CompletionSet> completionSets)
@@ -34,7 +34,7 @@ namespace AvaloniaVS.IntelliSense
                 var text = pos.Snapshot.GetText();
                 _buffer.Properties.TryGetProperty("AssemblyName", out string assemblyName);
                 var completions = _engine.GetCompletions(metadata.CompletionMetadata, text, pos, assemblyName);
-
+                
                 if (completions?.Completions.Count > 0)
                 {
                     var start = completions.StartPosition;

--- a/AvaloniaVS.Shared/IntelliSense/XamlTextManipulatorRegistrar.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlTextManipulatorRegistrar.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using Avalonia.Ide.CompletionEngine;
 using AvaloniaVS.Models;
+using AvaloniaVS.Shared.Completion.Manipulation;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Serilog;
@@ -38,13 +39,12 @@ namespace AvaloniaVS.IntelliSense
                     metadata.CompletionMetadata != null)
                 {
                     var sw = Stopwatch.StartNew();
-                    var pos = _textView.Caret.Position.BufferPosition;
                     var text = _buffer.CurrentSnapshot.GetText();
 
 
                     foreach (Microsoft.VisualStudio.Text.ITextChange change in e.Changes.ToList())
                     {
-                        var textManipulator = new TextManipulator(text, change.NewPosition);
+                        var textManipulator = new AvVSTextManipulator(text, change.NewPosition);
                         var avaloniaChange = new TextChangeAdapter(change);
                         var manipulations = textManipulator.ManipulateText(avaloniaChange);
                         if (manipulations?.Count > 0)

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -10,10 +10,9 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Avalonia.Ide.CompletionEngine;
-using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
-using Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
 using AvaloniaVS.Models;
 using AvaloniaVS.Services;
+using AvaloniaVS.Shared.Completion.Metadata;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
@@ -540,7 +539,7 @@ namespace AvaloniaVS.Views
                 {
                     metadataLoad = Task.Run(() =>
                                     {
-                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider());
+                                        var metadataReader = new AvVSMetadataReader();
                                         return metadataReader.GetForTargetAssembly(executablePath);
                                     });
                     _metadataCache[executablePath] = metadataLoad;


### PR DESCRIPTION
This PR adds a VisualStudio extension specific version of the CompletionEngine from Avalonia.IDE.CompletionEngine. This is needed to help advance the intellisense experience with this extension. I didn't remove the submodule to Avalonia.IDE.Completion and tried to preserve what could be, but some types have been copied over that are needed. This may result in duplicate code or the code diverging if upstream is ever updated, but I think that's a fair tradeoff for potentially faster development of completion within VS.

I've also, as a demo, added completion for pseudoclasses within Style Selectors:
![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/40413319/205422412-809bab62-b5b8-4520-86d2-d78111ebd46a.gif)

This is done by reading the `PseudoclassesAttribute` on supporting types. It's done through a nasty way, but it works - would be better if we had access to the `PseudoclassesAttribute` type to directly query that. I've also adjusted some of the completion logic so that pseudoclasses trigger a new completion session so typing "Control:" will list the pseudoclasses, previously because there's no space after 'Control', the engine wouldn't know to refilter the hints and we wouldn't get a list of suggestions since nothing matches "Control:". I've also made the char `-` NOT end a completion session for pseudoclasses like `:focus-within` allowing that to be typed without interruption. 

I've also fixed handling completion commit on '.' key. Currently typing 'Window.Resources', the '.' will cancel the completion session and swallow the '.' character so you'd have to press it twice to continue typing, which is suboptimal. Now the '.' character isn't swallowed and a new completion session is activated after pressing it.

Edit: I've also fixed the double intellisense popup when adding xml namespaces. I think VS XML service was starting its own and then we were starting one ourselves which was causing the double popups. The existing completion session already had an Avalonia completion set in it, so instead of creating a new session, I've made it just tap into that one.
![image](https://user-images.githubusercontent.com/40413319/205514694-a2ca62f3-e76d-4c43-aecb-9527104cf63d.png)


TODO:
- [x] Fix intellisense suggestions being suboptimal in ControlThemes
  - As an example, in ControlTheme, typing `<Setter Property="Tem` will suggested `TemplatedParent` and `TemplatedControl` but not the property `Template` (which is what's desired)

Future TODOs (not in this PR):
- find and list all defined resources instead of using static, hard-coded ones (hopefully, if not will add to future todos) that don't really apply to anything outside the old default theme
  - Ideally with this we need to make sure at least the active document (maybe even the current project) can update the suggestions more frequently without requiring a build (which is how the metadata is currently invalidated) as if you add a resource to the current file, I would expect it to immediately show without having to build the project. External assemblies could probably be cached like normal on build only since they're static unless the ref is explicitly updated

- Filter out non-public types from suggestions
- Add better context awareness for suggestions, including:
  - filtering the suggestions to only include what makes sense at the given point in the document (this is mostly already how it is, but I think there are a few places where this could be improved, as an example, don't suggest `VerticalContentAlignment` unless it absolutely makes sense to do so (only suggest `VerticalAlignment`)
  - In a Style Selector, we could probably make it only suggest things that make sense given the cursor position, ie don't suggest `/template/` or pseudoclasses at the start of the selector, no pseudoclasses directly after `/template/`, etc
  - In this PR, I've also added some code to tell VS to auto select the first suggestion in the list - previously, it wouldn't usually do this and you had to physically interact (mouse or arrow keys) to get the completion to work. We could probably improve this to guess the best item and select it instead based on context
- Fix editing existing text and accepting a completion
  - currently if you type `ponterover` and try to correct it, adding the `i` will suggest ":pointerover", but accepting that completion will end up with `pointerovernterover` as it just inserts the suggested text and doesn't check anything for replacing

closes #269
