### PR TITLE
Remove Avalonia submodule completely and fix build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/Avalonia"]
-	path = submodules/Avalonia
-	url = https://github.com/AvaloniaUI/Avalonia

--- a/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
+++ b/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
@@ -27,8 +27,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
-    <RestoreLockedMode>false</RestoreLockedMode>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>

--- a/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
+++ b/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
@@ -27,6 +27,8 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    <RestoreLockedMode>false</RestoreLockedMode>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>

--- a/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
+++ b/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
@@ -63,6 +63,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Avalonia.Remote.Protocol" Version="11.0-preview4" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
       <Version>15.8.243</Version>
     </PackageReference>
@@ -91,10 +92,6 @@
     <ProjectReference Include="..\CompletionEngine\Avalonia.Ide.CompletionEngine\Avalonia.Ide.CompletionEngine.csproj">
       <Project>{cd7db042-4282-4dfb-9910-958036dd621d}</Project>
       <Name>Avalonia.Ide.CompletionEngine</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\submodules\Avalonia\src\Avalonia.Remote.Protocol\Avalonia.Remote.Protocol.csproj">
-      <Project>{b089e051-a987-4946-ae04-e7eec3f91a7f}</Project>
-      <Name>Avalonia.Remote.Protocol</Name>
     </ProjectReference>
     <ProjectReference Include="..\templates\AvaloniaApplicationTemplate\AvaloniaApplicationTemplate.csproj">
       <Project>{75104aa0-3b1b-47d4-9c4d-501a8185acfc}</Project>

--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -27,8 +27,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
-    <RestoreLockedMode>false</RestoreLockedMode>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>

--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -27,6 +27,8 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    <RestoreLockedMode>false</RestoreLockedMode>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>

--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -63,6 +63,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Avalonia.Remote.Protocol" Version="11.0-preview4" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
       <Version>15.8.243</Version>
     </PackageReference>
@@ -99,10 +100,6 @@
     <ProjectReference Include="..\CompletionEngine\Avalonia.Ide.CompletionEngine\Avalonia.Ide.CompletionEngine.csproj">
       <Project>{cd7db042-4282-4dfb-9910-958036dd621d}</Project>
       <Name>Avalonia.Ide.CompletionEngine</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\submodules\Avalonia\src\Avalonia.Remote.Protocol\Avalonia.Remote.Protocol.csproj">
-      <Project>{b089e051-a987-4946-ae04-e7eec3f91a7f}</Project>
-      <Name>Avalonia.Remote.Protocol</Name>
     </ProjectReference>
     <ProjectReference Include="..\templates\AvaloniaApplicationTemplate\AvaloniaApplicationTemplate.csproj">
       <Project>{75104aa0-3b1b-47d4-9c4d-501a8185acfc}</Project>

--- a/AvaloniaVS.sln
+++ b/AvaloniaVS.sln
@@ -3,10 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "submodules", "submodules", "{BA40CDDD-84AA-4B4A-A729-7EFB9E1E9B22}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Remote.Protocol", "submodules\Avalonia\src\Avalonia.Remote.Protocol\Avalonia.Remote.Protocol.csproj", "{B089E051-A987-4946-AE04-E7EEC3F91A7F}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{FC634911-168A-4FDD-8758-11FAD5B8696B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvaloniaApplicationTemplate", "templates\AvaloniaApplicationTemplate\AvaloniaApplicationTemplate.csproj", "{75104AA0-3B1B-47D4-9C4D-501A8185ACFC}"
@@ -59,14 +55,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Debug|x86.Build.0 = Debug|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Release|x86.ActiveCfg = Release|Any CPU
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F}.Release|x86.Build.0 = Release|Any CPU
 		{75104AA0-3B1B-47D4-9C4D-501A8185ACFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{75104AA0-3B1B-47D4-9C4D-501A8185ACFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75104AA0-3B1B-47D4-9C4D-501A8185ACFC}.Debug|x86.ActiveCfg = Debug|x86
@@ -200,7 +188,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{B089E051-A987-4946-AE04-E7EEC3F91A7F} = {BA40CDDD-84AA-4B4A-A729-7EFB9E1E9B22}
 		{75104AA0-3B1B-47D4-9C4D-501A8185ACFC} = {FC634911-168A-4FDD-8758-11FAD5B8696B}
 		{D458691F-3B40-4E54-8BC2-782D017CFD2B} = {FC634911-168A-4FDD-8758-11FAD5B8696B}
 		{3BFD12BB-E6D8-46D7-9D5F-119A9896941E} = {FC634911-168A-4FDD-8758-11FAD5B8696B}

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RuntimeIdentifiers>any</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
     <SignAssembly>true</SignAssembly>

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RuntimeIdentifiers>any</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
     <SignAssembly>true</SignAssembly>

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RuntimeIdentifiers>any</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
     <SignAssembly>true</SignAssembly>

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RuntimeIdentifiers>any</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
     <SignAssembly>true</SignAssembly>

--- a/CompletionEngine/CompletionEngineTests/CompletionEngineTests.csproj
+++ b/CompletionEngine/CompletionEngineTests/CompletionEngineTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 variables:
   solution: 'AvaloniaVS.sln'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,15 +21,15 @@ steps:
   inputs:
     command: 'restore'
 
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'test'
+
 - task: VSBuild@1
   inputs:
     solution: '$(solution)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
-    
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'test'
 
 - task: CopyFiles@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: 'test'
+    projects: '.\CompletionEngine\CompletionEngineTests\CompletionEngineTests.csproj'
 
 - task: VSBuild@1
   inputs:


### PR DESCRIPTION
We only use Avalonia.Remote.Protocol project from the submodule. There are no reasons to not use nuget package at this point.