### PR TITLE
Fix previewer splitter 

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml
@@ -139,6 +139,7 @@
                           Grid.Row="1"
                           Grid.Column="1"
                           VerticalAlignment="Stretch"
+                          HorizontalAlignment="Stretch"
                           Height="5"
                           Background="{DynamicResource VsBrush.PanelSeparator}"/>
 


### PR DESCRIPTION
Accidentally removed the HorizontalAlignment=Stretch on the GridSplitter in the previewer while doing #284 which broke it. PR just adds that back to fix it.