### PR TITLE
Include CLI templates in VSIX

### DIFF
--- a/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
+++ b/AvaloniaVS.VS2019AndEarlier/AvaloniaVS.VS2019AndEarlier.csproj
@@ -85,7 +85,23 @@
       <Version>0.15.0</Version>
     </PackageReference>
   </ItemGroup>
+  
+  <Target Name="PreCreateVsixContainer" BeforeTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <_TemplatePackage Include="$(NuGetPackageRoot)\$(AvaloniaTemplatesPackageName.ToLowerInvariant())\$(AvaloniaTemplatesPackageVersion)\$(AvaloniaTemplatesPackageName.ToLowerInvariant()).$(AvaloniaTemplatesPackageVersion).nupkg" />
+    </ItemGroup>
+    <Error Text="No template files found." Condition="@(_TemplatePackage-&gt;Count()) == 0" />
+    <Message Text="Template nuget packages found: @(_TemplatePackage)" Importance="low" />
+    <!-- don't modify the following, the pkgdef file uses the path below -->
+    <ItemGroup>
+      <VSIXSourceItem Include="@(_TemplatePackage)">
+        <VSIXSubPath>ProjectTemplates\</VSIXSubPath>
+      </VSIXSourceItem>
+    </ItemGroup>
+  </Target>
+  
   <ItemGroup>
+    <ProjectReference Include="..\templates\ProjectTemplatesDownloader\ProjectTemplatesDownloader.csproj" ReferenceOutputAssembly="false" PrivateAssets="all"  />
     <ProjectReference Include="..\CompletionEngine\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj">
       <Project>{5f0f9262-3527-46af-acf6-986b7f7b4c90}</Project>
       <Name>Avalonia.Ide.CompletionEngine.DnlibMetadataProvider</Name>
@@ -163,6 +179,12 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Templates.pkgdef">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="..\AvaloniaVS.Shared\AvaloniaVS.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AvaloniaVS.VS2019AndEarlier/Templates.pkgdef
+++ b/AvaloniaVS.VS2019AndEarlier/Templates.pkgdef
@@ -1,0 +1,2 @@
+﻿[$RootKey$\TemplateEngine\Templates\avalonia.templates.nuspec\0.10.18.5]
+"InstalledPath"="$PackageFolder$\ProjectTemplates"

--- a/AvaloniaVS.VS2019AndEarlier/source.extension.vsixmanifest
+++ b/AvaloniaVS.VS2019AndEarlier/source.extension.vsixmanifest
@@ -26,5 +26,6 @@
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="AvaloniaResourceDictionaryTemplate" d:TargetPath="|AvaloniaResourceDictionaryTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="AvaloniaStylesTemplate" d:TargetPath="|AvaloniaStylesTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="FsAvaloniaTemplatedControlTemplate" d:TargetPath="|FsAvaloniaTemplatedControlTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Templates.pkgdef" />
     </Assets>
 </PackageManifest>

--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -63,6 +63,19 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <Target Name="PreCreateVsixContainer" BeforeTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <_TemplatePackage Include="$(NuGetPackageRoot)\$(AvaloniaTemplatesPackageName.ToLowerInvariant())\$(AvaloniaTemplatesPackageVersion)\$(AvaloniaTemplatesPackageName.ToLowerInvariant()).$(AvaloniaTemplatesPackageVersion).nupkg" />
+    </ItemGroup>
+    <Error Text="No template files found." Condition="@(_TemplatePackage-&gt;Count()) == 0" />
+    <Message Text="Template nuget packages found: @(_TemplatePackage)" Importance="low" />
+    <!-- don't modify the following, the pkgdef file uses the path below -->
+    <ItemGroup>
+      <VSIXSourceItem Include="@(_TemplatePackage)">
+        <VSIXSubPath>ProjectTemplates\</VSIXSubPath>
+      </VSIXSourceItem>
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <PackageReference Include="Avalonia.Remote.Protocol" Version="11.0-preview4" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
@@ -94,6 +107,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\templates\ProjectTemplatesDownloader\ProjectTemplatesDownloader.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
     <ProjectReference Include="..\CompletionEngine\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider\Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj">
       <Project>{5f0f9262-3527-46af-acf6-986b7f7b4c90}</Project>
       <Name>Avalonia.Ide.CompletionEngine.DnlibMetadataProvider</Name>
@@ -158,6 +172,12 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Templates.pkgdef">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
   </ItemGroup>
   <Import Project="..\AvaloniaVS.Shared\AvaloniaVS.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AvaloniaVS.VS2022/Templates.pkgdef
+++ b/AvaloniaVS.VS2022/Templates.pkgdef
@@ -1,0 +1,2 @@
+﻿[$RootKey$\TemplateEngine\Templates\avalonia.templates.nuspec\0.10.18.5]
+"InstalledPath"="$PackageFolder$\ProjectTemplates"

--- a/AvaloniaVS.VS2022/source.extension.vsixmanifest
+++ b/AvaloniaVS.VS2022/source.extension.vsixmanifest
@@ -31,5 +31,6 @@
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="AvaloniaResourceDictionaryTemplate" d:TargetPath="|AvaloniaResourceDictionaryTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="AvaloniaStylesTemplate" d:TargetPath="|AvaloniaStylesTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="FsAvaloniaTemplatedControlTemplate" d:TargetPath="|FsAvaloniaTemplatedControlTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Templates.pkgdef" />
     </Assets>
 </PackageManifest>

--- a/AvaloniaVS.sln
+++ b/AvaloniaVS.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		azure-pipelines.yml = azure-pipelines.yml
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Ide.CompletionEngine", "CompletionEngine\Avalonia.Ide.CompletionEngine\Avalonia.Ide.CompletionEngine.csproj", "{CD7DB042-4282-4DFB-9910-958036DD621D}"
@@ -46,6 +47,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAssembly2", "tests\TestAssembly2\TestAssembly2.csproj", "{0D792D9B-66F7-46DB-AC87-AA3068151E6C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FsAvaloniaTemplatedControlTemplate", "templates\FsAvaloniaTemplatedControlTemplate\FsAvaloniaTemplatedControlTemplate.csproj", "{94AFBDF7-D3C5-4952-9070-5A517970B964}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectTemplatesDownloader", "templates\ProjectTemplatesDownloader\ProjectTemplatesDownloader.csproj", "{14C474FC-E529-4148-ADEB-E9F77E744452}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -175,6 +178,14 @@ Global
 		{94AFBDF7-D3C5-4952-9070-5A517970B964}.Release|Any CPU.Build.0 = Release|Any CPU
 		{94AFBDF7-D3C5-4952-9070-5A517970B964}.Release|x86.ActiveCfg = Release|x86
 		{94AFBDF7-D3C5-4952-9070-5A517970B964}.Release|x86.Build.0 = Release|x86
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Debug|x86.Build.0 = Debug|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Release|x86.ActiveCfg = Release|Any CPU
+		{14C474FC-E529-4148-ADEB-E9F77E744452}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,6 +204,7 @@ Global
 		{26CB0499-10FE-4CC1-9F20-4738BF527494} = {3CF4E8CC-E706-41DC-8A22-8E37EDA7E599}
 		{0D792D9B-66F7-46DB-AC87-AA3068151E6C} = {3CF4E8CC-E706-41DC-8A22-8E37EDA7E599}
 		{94AFBDF7-D3C5-4952-9070-5A517970B964} = {FC634911-168A-4FDD-8758-11FAD5B8696B}
+		{14C474FC-E529-4148-ADEB-E9F77E744452} = {FC634911-168A-4FDD-8758-11FAD5B8696B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0CE7163D-D505-4965-B2B9-9E9068C77A62}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <AvaloniaTemplatesPackageName>Avalonia.Templates</AvaloniaTemplatesPackageName>
+    <AvaloniaTemplatesPackageVersion>0.10.18.5</AvaloniaTemplatesPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/templates/ProjectTemplatesDownloader/ProjectTemplatesDownloader.csproj
+++ b/templates/ProjectTemplatesDownloader/ProjectTemplatesDownloader.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--This project is needed to download Avalonia CLI templates, we can't download them from main projects because PackageDownload requires SDK-style project
+  and our main projects can't be migrated to SDK-style.-->
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageDownload Include="$(AvaloniaTemplatesPackageName)" Version="[$(AvaloniaTemplatesPackageVersion)]" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
This PR includes Avalonia CLI templates in our VSIX. But as @Mrxx99 commented it has one drawback. If you have CLI templates they would be preferred over VS extension templates so you will need to update CLI templates first.