### PR TITLE
Change target framework to net472 for ProjectTemplateDownloader

### DIFF
--- a/templates/ProjectTemplatesDownloader/ProjectTemplatesDownloader.csproj
+++ b/templates/ProjectTemplatesDownloader/ProjectTemplatesDownloader.csproj
@@ -3,7 +3,7 @@
   <!--This project is needed to download Avalonia CLI templates, we can't download them from main projects because PackageDownload requires SDK-style project
   and our main projects can't be migrated to SDK-style.-->
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Changed the target framework for the ProjectTemplateDownloader to net472 from net45. As in [this comment](https://github.com/AvaloniaUI/AvaloniaVS/pull/291#discussion_r1093819930) if net45 developer pack isn't installed there's no way to install it as its out of service. 