### PR TITLE
Use System.Text.Json 4.6.0

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -8,7 +8,11 @@
     <AssemblyOriginatorKeyFile>$(SolutionDir)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+    <!-- 
+    Must use oldest System.Text.Json version here as this can't be higher than what VS ships with
+    or intellisense will fail to load - see GH#298
+    -->
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 


### PR DESCRIPTION
Use the oldest version of `System.Text.Json` to prevent issues with VisualStudio.

I also left a comment in there so nobody inadvertently changes it in the future, at least without checking with VS

fixes #298