### PR TITLE
More VS IntelliSense improvements

### DIFF
--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletion.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletion.cs
@@ -69,6 +69,7 @@ namespace AvaloniaVS.IntelliSense
             s_images[(int)CompletionKind.AttachedProperty] = KnownMonikers.Property;
             s_images[(int)CompletionKind.StaticProperty] = KnownMonikers.EnumerationItemPublic;
             s_images[(int)CompletionKind.MarkupExtension] = KnownMonikers.Namespace;
+            s_images[(int)CompletionKind.DataProperty] = KnownMonikers.DatabaseProperty;
         }
     }
 }

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletion.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletion.cs
@@ -32,6 +32,7 @@ namespace AvaloniaVS.IntelliSense
         }
 
         public int CursorOffset { get; }
+
         public CompletionKind Kind { get; }
 
         public static IEnumerable<XamlCompletion> Create(
@@ -49,7 +50,25 @@ namespace AvaloniaVS.IntelliSense
                 LoadImages();
             }
 
+            if (HasFlag(kind, CompletionKind.DataProperty))
+            {
+                return s_images[(int)CompletionKind.DataProperty];
+            }
+            else if (HasFlag(kind, CompletionKind.TargetTypeClass))
+            {
+                return s_images[(int)CompletionKind.TargetTypeClass];
+            }
+            else if (HasFlag(kind, CompletionKind.VS_XMLNS))
+            {
+                return s_images[(int)CompletionKind.Enum];
+            }
+
             return s_images[(int)kind];
+
+            bool HasFlag(CompletionKind test, CompletionKind expected)
+            {
+                return (test & expected) == expected;
+            }
         }
 
         private static void LoadImages()
@@ -70,6 +89,7 @@ namespace AvaloniaVS.IntelliSense
             s_images[(int)CompletionKind.StaticProperty] = KnownMonikers.EnumerationItemPublic;
             s_images[(int)CompletionKind.MarkupExtension] = KnownMonikers.Namespace;
             s_images[(int)CompletionKind.DataProperty] = KnownMonikers.DatabaseProperty;
+            s_images[(int)CompletionKind.TargetTypeClass] = KnownMonikers.ClassPublic;
         }
     }
 }

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -261,7 +261,10 @@ namespace AvaloniaVS.IntelliSense
 
                                 // if in a markup extension, if we skip the entered char, we won't get
                                 // to start a new completion session, so force start it
-                                if (skip)
+                                // The check for '=' in the insertion text ensures we don't always get this
+                                // e.g., {OnPlatform Wind -> {OnPlatform Windows= [New completion session]
+                                // but {OnPlatform Windows=Re -> {OnPlatform Windows=Red [no new session]
+                                if (skip && selected.InsertionText.EndsWith("="))
                                     TriggerCompletion();
                             }
                         }

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -251,7 +251,7 @@ namespace AvaloniaVS.IntelliSense
                                 for (int i = text.Length - 1; i >= 0; i--)
                                 {
                                     var lineChar = text[i];
-                                    if (char.IsLetter(lineChar) || char.IsNumber(lineChar) || lineChar == ':')
+                                    if (char.IsLetterOrDigit(lineChar) || lineChar == ':')
                                         continue;
 
                                     // any other character than [A-z,0-9,:] is a different part

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -93,7 +93,7 @@ namespace AvaloniaVS.IntelliSense
                 {
                     return VSConstants.S_OK;
                 }
-                
+
                 return result;
             }
 
@@ -289,7 +289,8 @@ namespace AvaloniaVS.IntelliSense
                         // Cases like {Binding Path= result in {Binding Path==
                         // as the completion includes the '=', if the entered char
                         // is the same as the last char here, swallow the entered char
-                        if (!skip && selected.InsertionText.EndsWith(c.ToString()))
+                        if (!skip && (selected.InsertionText?.Length > 0 && 
+                            selected.InsertionText[selected.InsertionText.Length - 1] == c))
                         {
                             skip = true;
 

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -264,7 +264,7 @@ namespace AvaloniaVS.IntelliSense
                         else
                         {
                             skip = false;
-                        }                        
+                        }
 
                         // Cases like {Binding Path= result in {Binding Path==
                         // as the completion includes the '=', if the entered char
@@ -272,7 +272,7 @@ namespace AvaloniaVS.IntelliSense
                         if (!skip && selected.InsertionText.EndsWith(c.ToString()))
                         {
                             skip = true;
-                    }
+                        }
                     }
                     else if (state != XmlParser.ParserState.StartElement)
                     {

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using AvaloniaVS.Models;
 using Microsoft.VisualStudio.Language.Intellisense;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Serilog;
 using CompletionEngine = Avalonia.Ide.CompletionEngine.CompletionEngine;
@@ -37,6 +36,7 @@ namespace AvaloniaVS.IntelliSense
                 {
                     var start = completions.StartPosition;
 
+                    // TODO: this should be handled in the completion engine
                     // pseudoclasses should only be returned in a Selector, so this is an easy filter
                     // We need to offset the start though for pseudoclasses to remove what they're 
                     // attached to: Control:pointerover -> :pointerover

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionSource.cs
@@ -14,13 +14,11 @@ namespace AvaloniaVS.IntelliSense
     internal class XamlCompletionSource : ICompletionSource
     {
         private readonly ITextBuffer _buffer;
-        private readonly IVsImageService2 _imageService;
         private readonly CompletionEngine _engine;
 
-        public XamlCompletionSource(ITextBuffer textBuffer, IVsImageService2 imageService)
+        public XamlCompletionSource(ITextBuffer textBuffer)
         {
             _buffer = textBuffer;
-            _imageService = imageService;
             _engine = new CompletionEngine();
         }
 
@@ -61,7 +59,7 @@ namespace AvaloniaVS.IntelliSense
                         "Avalonia",
                         "Avalonia",
                         applicableTo,
-                        XamlCompletion.Create(completions.Completions, _imageService),
+                        XamlCompletion.Create(completions.Completions),
                         null));
 
                     // This selects the first item in the completion popup - otherwise you have to physically

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionSourceProvider.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionSourceProvider.cs
@@ -14,20 +14,11 @@ namespace AvaloniaVS.IntelliSense
     [Name("Avalonia XAML Completion")]
     internal class XamlCompletionSourceProvider : ICompletionSourceProvider
     {
-        private readonly IVsImageService2 _imageService;
-
-        [ImportingConstructor]
-        public XamlCompletionSourceProvider(
-            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
-        {
-            _imageService = serviceProvider.GetService<IVsImageService2, SVsImageService>();
-        }
-
         public ICompletionSource TryCreateCompletionSource(ITextBuffer textBuffer)
         {
             if (textBuffer.Properties.ContainsProperty(typeof(XamlBufferMetadata)))
             {
-                return new XamlCompletionSource(textBuffer, _imageService);
+                return new XamlCompletionSource(textBuffer);
             }
 
             return null;

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -45,6 +45,11 @@ public static class MetadataConverter
         {
             return true;
         }
+        else if (type.Name.Equals("OnPlatformExtension"))
+        {
+            // Special case for this, as it the type info can't find the ProvideValue method
+            return true;
+        }
 
         return false;
     }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -45,7 +45,7 @@ public static class MetadataConverter
         {
             return true;
         }
-        else if (type.Name.Equals("OnPlatformExtension"))
+        else if (type.Name.Equals("OnPlatformExtension") || type.Name.Equals("OnFormFactorExtension"))
         {
             // Special case for this, as it the type info can't find the ProvideValue method
             return true;

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
@@ -1,5 +1,8 @@
-﻿namespace Avalonia.Ide.CompletionEngine;
+﻿using System;
 
+namespace Avalonia.Ide.CompletionEngine;
+
+[Flags]
 public enum CompletionKind
 {
     None = 0x0,

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
@@ -2,22 +2,33 @@
 
 public enum CompletionKind
 {
-    None,
-    Class,
-    Property,
-    AttachedProperty,
-    StaticProperty,
-    Namespace,
-    Enum,
-    MarkupExtension,
-    Event,
-    AttachedEvent,
+    None = 0x0,
+    Class = 0x1,
+    Property = 0x2,
+    AttachedProperty = 0x4,
+    StaticProperty = 0x8,
+    Namespace = 0x10,
+    Enum = 0x20,
+    MarkupExtension = 0x40,
+    Event = 0x80,
+    AttachedEvent = 0x100,
 
     /// <summary>
     /// Properties from DataContexts (view models), specifically this is for VS
     /// to use a different icon from normal properties
     /// </summary>
-    DataProperty
+    DataProperty = 0x200,
+
+    /// <summary>
+    /// Classes when listed from TargetType or Selector, specfically for VS to use
+    /// a different icon from <see cref="Class"/> used in tag names
+    /// </summary>
+    TargetTypeClass = 0x400,
+
+    /// <summary>
+    /// xmlns list in visual studio (uses enum icon instead of namespace icon)
+    /// </summary>
+    VS_XMLNS = 0x800
 }
 
 public record Completion(string DisplayText, string InsertText, string Description, CompletionKind Kind, int? RecommendedCursorOffset = null)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/Completion.cs
@@ -11,7 +11,13 @@ public enum CompletionKind
     Enum,
     MarkupExtension,
     Event,
-    AttachedEvent
+    AttachedEvent,
+
+    /// <summary>
+    /// Properties from DataContexts (view models), specifically this is for VS
+    /// to use a different icon from normal properties
+    /// </summary>
+    DataProperty
 }
 
 public record Completion(string DisplayText, string InsertText, string Description, CompletionKind Kind, int? RecommendedCursorOffset = null)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -248,7 +248,7 @@ public class CompletionEngine
             else
             {
                 completions.AddRange(_helper.FilterTypes(tagName).Select(kvp =>
-                { 
+                {
                     if (kvp.Value.IsMarkupExtension)
                     {
                         var xamlName = kvp.Key.Substring(0, kvp.Key.Length - 9 /* length of "extension" */);
@@ -505,7 +505,16 @@ public class CompletionEngine
 
         if (type.HintValues is not null)
         {
-            foreach (var v in type.HintValues.Where(v => v.StartsWith(entered, StringComparison.OrdinalIgnoreCase)))
+            // Don't filter values here by 'StartsWith' (old behavior), provide all the hints,
+            // For VS, Intellisense will filter the results for us, other users of the completion
+            // engine (outside of VS) will need to filter later
+            // Otherwise, in VS, it's impossible to get the full list for something like brushes:
+            // Background="Red" -> Background="B", will only populate with the 'B' brushes and hitting
+            // backspace after that will keep the 'B' brushes only instead of showing the whole list
+            // WPF/UWP loads the full list of brushes and highlights starting at the B and then
+            // filters the list down from there - otherwise its difficult to keep the completion list
+            // and see all choices if making edits
+            foreach (var v in type.HintValues)
             {
                 yield return v;
             }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -724,7 +724,8 @@ public class CompletionEngine
     {
         return char.IsLetterOrDigit(typedChar) || typedChar == '/' || typedChar == '<'
             || typedChar == ' ' || typedChar == '.' || typedChar == ':' || typedChar == '$'
-            || typedChar == '#' || typedChar == '-' || typedChar == '^';
+            || typedChar == '#' || typedChar == '-' || typedChar == '^' || typedChar == '{'
+            || typedChar == '=';
     }
 
     public static CompletionKind GetCompletionKindForHintValues(MetadataType type)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -76,7 +76,8 @@ public class CompletionEngine
             prefix ??= "";
 
             var e = _types
-                .Where(t => t.Value.IsXamlDirective == xamlDirectiveOnly && t.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+                .Where(t => t.Value.IsXamlDirective == xamlDirectiveOnly && t.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .Where(x => !x.Key.Equals("ControlTemplateResult") && !x.Key.Equals("DataTemplateExtensions"));
             if (withAttachedPropertiesOrEventsOnly)
                 e = e.Where(t => t.Value.HasAttachedProperties || t.Value.HasAttachedEvents);
             if (markupExtensionsOnly)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -578,7 +578,7 @@ public class CompletionEngine
             {
                 foreach (var propertyName in MetadataHelper.FilterPropertyNames(filterType, filter, false, false))
                 {
-                    yield return new Completion(propertyName, fmtInsertText?.Invoke(propertyName) ?? propertyName, propertyName, CompletionKind.Property);
+                    yield return new Completion(propertyName, fmtInsertText?.Invoke(propertyName) ?? propertyName, propertyName, CompletionKind.DataProperty);
                 }
             }
         }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -152,7 +152,7 @@ public class CompletionEngine
             return t.Events.Where(n => n.IsAttached == attached && n.Name.StartsWith(propName)).Select(n => n.Name);
         }
 
-        public MetadataProperty? LookupProperty(string typeName, string? propName)
+        public MetadataProperty? LookupProperty(string? typeName, string? propName)
             => LookupType(typeName)?.Properties?.FirstOrDefault(p => p.Name == propName);
     }
 
@@ -420,10 +420,10 @@ public class CompletionEngine
                 }
                 else if (state.TagName == "On")
                 {
-                    if (state.AttributeName.Equals("Options"))
+                    if (state?.AttributeName?.Equals("Options") == true)
                     {
                         var parentTag = state.GetParentTagName(1);
-                        if (parentTag.Equals("OnPlatform"))
+                        if (parentTag?.Equals("OnPlatform") == true)
                         {
                             // Built in types from:
                             //https://github.com/AvaloniaUI/Avalonia/blob/master/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -434,16 +434,16 @@ public class CompletionEngine
                             completions.Add(new Completion("IOS", CompletionKind.Enum));
                             completions.Add(new Completion("Browser", CompletionKind.Enum));
                         }
-                        else if (parentTag.Equals("OnFormFactor"))
+                        else if (parentTag?.Equals("OnFormFactor") == true)
                         {
                             completions.Add(new Completion("Desktop", CompletionKind.Enum));
                             completions.Add(new Completion("Mobile", CompletionKind.Enum));
                         }
                     }
-                    else if (state.AttributeName.Equals("Content"))
+                    else if (state?.AttributeName?.Equals("Content") == true)
                     {
                         // For content, lets find the completions relevant to the property
-                        var propertyTag = state.GetParentTagName(2);
+                        var propertyTag = state.GetParentTagName(2)!;
                         var dotPos = propertyTag.IndexOf(".");
                         var typeName = propertyTag.Substring(0, dotPos);
                         var compName = propertyTag.Substring(dotPos + 1);
@@ -748,7 +748,7 @@ public class CompletionEngine
                 }
                 else
                 {
-                    var prop = _helper.LookupProperty(state.TagName, state.AttributeName);
+                    var prop = _helper.LookupProperty(state?.TagName, state?.AttributeName);
                     if (prop?.Type?.HasHintValues == true)
                     {
                         completions.AddRange(GetHintCompletions(prop.Type, null, currentAssemblyName));

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -711,6 +711,10 @@ public class CompletionEngine
 
             if ((isOnPlatform == true) || (isOnFormFactor == true))
             {
+                // If we type a comma after a previous attribute: // {Binding Path=MyProp,
+                // the parser shows that as InsideElement, though we really want that to
+                // be StartAttribute for a list of completions relevant to the markup extension
+                // i.e., above we'd get the completion list for {Binding} again
                 bool isActuallyStartAttribute = false;
                 for (int i = data.Length - 1; i >= 0; i--)
                 {

--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -139,10 +139,9 @@ namespace CompletionEngineTests
         {
             var compl = GetCompletionsFor("<DataTemplate");
 
-            Assert.Equal(3, compl.Completions.Count);
+            Assert.Equal(2, compl.Completions.Count);
             Assert.Equal("DataTemplate", compl.Completions[0].InsertText);
-            Assert.Equal("DataTemplateExtensions", compl.Completions[1].InsertText);
-            Assert.Equal("DataTemplates", compl.Completions[2].InsertText);
+            Assert.Equal("DataTemplates", compl.Completions[1].InsertText);
         }
     }
 }


### PR DESCRIPTION
Several improvements, mostly to the VS side of things
- I noticed after the Completion engine refactor, typing something like "Grid." was inserting two periods ("Grid..") for some reason, fixed that
- Updated the logic (even some I had previously done) to improve completion handling to better match the UWP/WPF designers
  - Typing a namespace should no longer take the selected completion option when typing a period. only tab and space can accept a completion while editing a namespace
  - Elsewhere, tab and space can trigger a completion. The tab is always swallowed and isn't entered into the text buffer. A space is only entered into the buffer in a Selector, as it doesn't make sense in most attributes (Background="Red" shouldn't complete to Background="Red ")
- Improved AttachedProperties in Setters. This required a breaking change in the completion engine. In the current version, when the new completion session pop up after the period (like `Grid.`), no options are selected and continuing to type (even something valid like Column or Row for Grid.) would cancel intellisense. The completion engine was providing attached properties with the type name attached ("Grid.Row") which wasn't matching the completion buffer which reset at the period. I changed the completion engine to only supply the property name, which fixes this issue and completion now works entirely for attached properties. 
- Added better support for Markup extension used as XML elements instead of Attributes (StaticResource, OnPlatform, etc)
- Manually filtered out `ControlTemplateResult` and `DataTemplateExtensions` from the type list. They're irrelevant to xaml and seem to be the most commonly noticed. IMO, we really need an attribute for public types to hide them from the designer if the type must be public (EditorBrowsable doesn't work since the type may be useful in C# and it would hide there too)

- Updated to `Completion4`. Not really a change that really matters but uses a more modern VS class. Change removed the IVsImageService from the MEF completion provider as Completion4 uses `ImageMoniker`s instead of `ImageSource`.
- Updated a couple of the icons to better match WPF/UWP, specifically for classes/controls (only difference is that ours is colored, don't know why but a touch of color is kinda nice):
![image](https://user-images.githubusercontent.com/40413319/220512716-ac8af046-03a2-460f-ad8c-057f4bac9920.png)

and static classes like Brushes now use the enum icon:
![image](https://user-images.githubusercontent.com/40413319/220512867-c3df939f-ea4f-4834-b6e9-50ab47e81dbf.png)


Still a draft PR as:
- <s>I found an issue taking that last screenshot (typing "Red" then backspacing and changing the color doesn't refresh the completion list)</s>
- There's a couple random errors popping up, one is related to the ErrorTagger, which is irrelevant to the changes made here, and the other is occasionally a new completion session will try to start while another is active. Neither are easily repro'd but if I can figure out why I'll see what I can do.
- Need to fix/add tests

-------

UPDATE:
- Improved completion in markup extensions as whole
- Added full support for the `OnPlatform` and `OnFormFactor` markup extensions, including having the appropriate completions suggested depending on context
- Changed the icon for completion properties when in a DataType/DataContext completion session. The icon is now the same image ID/moniker as the WPF/UWP designer, but it looks a bit different b/c of how old the WPF designer is which isn't using the new icon set (that's my guess at least)

Inline:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/40413319/220819232-d4fc1c35-e8b0-4aec-bbfa-1b3c32720f3d.gif)

And:
![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/40413319/220819259-0d122909-3036-4c6a-b3ca-79e361523609.gif)

--------

UPDATE 2:
Changed a couple more icons to match the WPF/UWP: 
- TargetType (and in future types in Selector) use a different icon for class than the one used for tag names ,
- Completions for xmlns use the enum icon
- For these, I changed the `CompletionKind` enum to be essentially a Flags enum so these VS specific kinds don't interfere with other uses


