### PR TITLE
feat: Allow AvaloniaVS defered load

### DIFF
--- a/AvaloniaVS.Shared/AvaloniaPackage.cs
+++ b/AvaloniaVS.Shared/AvaloniaPackage.cs
@@ -16,7 +16,6 @@ namespace AvaloniaVS
     [Guid(Constants.PackageGuidString)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideEditorExtension(
         typeof(EditorFactory),
         "." + Constants.axaml,
@@ -64,8 +63,6 @@ namespace AvaloniaVS
         DebuggingLogicalViewEditor = typeof(EditorFactory),
         TextLogicalViewEditor = typeof(EditorFactory))]
     [ProvideOptionPage(typeof(OptionsDialogPage), Constants.PackageName, "General", 113, 0, supportsAutomation: true)]
-
-
     [ProvideBindingPath]
     internal sealed class AvaloniaPackage : AsyncPackage
     {

--- a/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
+++ b/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
@@ -15,7 +15,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EnumValuesConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\NotNullOrEmptyToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Guids.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntelliSense\TextChangeAdapter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntelliSense\XamlCompletion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntelliSense\XamlCompletionCommandHandler.cs" />
@@ -31,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\ProjectInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\ProjectOutputInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\XamlBufferMetadata.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\AvaloniaProject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ServiceProviderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\AvaloniaVSSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\EditorFactory.cs" />

--- a/AvaloniaVS.Shared/Constants.cs
+++ b/AvaloniaVS.Shared/Constants.cs
@@ -1,13 +1,18 @@
-﻿namespace AvaloniaVS;
+﻿using System;
+
+namespace AvaloniaVS;
 
 internal static class Constants
 {
     public const string PackageGuidString = "865ba8d5-1180-4bf8-8821-345f72a4cb79";
+    public static readonly Guid PackageGuid = new (PackageGuidString);
     public const string PackageName = "Avalonia Xaml Editor";
     public const string axaml = nameof(axaml);
     public const string xaml = nameof(xaml);
     public const string paml = nameof(paml);
 
     public const string AvaloviaFactoryEditorGuidString = @"6D5344A2-2FCD-49DE-A09D-6A14FD1B1224";
+    public static readonly Guid AvaloviaFactoryEditorGuid = new (AvaloviaFactoryEditorGuidString);
 
+    public const string AvaloniaCapability = nameof(Avalonia);
 }

--- a/AvaloniaVS.Shared/Guids.cs
+++ b/AvaloniaVS.Shared/Guids.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace AvaloniaVS
-{
-    internal static class Guids
-    {
-        public static readonly Guid AvaloniaDesignerEditorFactory = new Guid("47020D9A-09A4-4BA2-83A4-43D07D3E8D6E");
-    }
-}

--- a/AvaloniaVS.Shared/ProjectSystem/AvaloniaProject.cs
+++ b/AvaloniaVS.Shared/ProjectSystem/AvaloniaProject.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+using System.ComponentModel.Composition;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace AvaloniaVS.ProjectSystem;
+
+[Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
+[AppliesTo(Constants.AvaloniaCapability)]
+internal class AvaloniaProject : IProjectDynamicLoadComponent
+{
+    private IAsyncServiceProvider asyncServiceProvider;
+
+    public async Task LoadAsync()
+    {
+        if (asyncServiceProvider is null)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            if (ServiceProvider.GlobalProvider.GetService(typeof(IVsShell)) is IVsShell shell)
+            {
+                if (shell.IsPackageLoaded(Constants.PackageGuid, out var vsPackage)
+                   != Microsoft.VisualStudio.VSConstants.S_OK)
+                {
+                    shell.LoadPackage(Constants.PackageGuid, out vsPackage);
+                }
+                asyncServiceProvider = (IAsyncServiceProvider)vsPackage;
+            }
+        }
+    }
+
+    public async Task UnloadAsync()
+    {
+        // Unload the feature
+        await Task.CompletedTask;
+    }
+}

--- a/AvaloniaVS.Shared/Services/EditorFactory.cs
+++ b/AvaloniaVS.Shared/Services/EditorFactory.cs
@@ -76,7 +76,7 @@ namespace AvaloniaVS.Services
 
             ppunkDocView = IntPtr.Zero;
             ppunkDocData = IntPtr.Zero;
-            pguidCmdUI = Guids.AvaloniaDesignerEditorFactory;
+            pguidCmdUI = Constants.AvaloviaFactoryEditorGuid;
             pgrfCDW = 0;
             pbstrEditorCaption = string.Empty;
 

--- a/AvaloniaVS.Shared/Views/EditorPane.cs
+++ b/AvaloniaVS.Shared/Views/EditorPane.cs
@@ -236,7 +236,7 @@ namespace AvaloniaVS.Shared.Views
 
         int IVsDeferredDocView.get_CmdUIGuid(out System.Guid pGuidCmdId)
         {
-            pGuidCmdId = Guids.AvaloniaDesignerEditorFactory;
+            pGuidCmdId = Constants.AvaloviaFactoryEditorGuid;
             return VSConstants.S_OK;
         }
 


### PR DESCRIPTION
Allow loading the AvaloniaVS extension when referencing the Avalonia nuget package or add ProjectCapability Avalonia to project

[Doc](https://github.com/microsoft/VSProjectSystem/blob/2a8735daf164b0c2f93ab968357dfd278200595d/doc/overview/dynamicCapabilities.md)

### Example to Add ProjectCapability  to project
```xml
  <ItemGroup>
    <ProjectCapability Include="Avalonia"/>
  </ItemGroup>
```

Fixes #311
Depend of  AvaloniaUI/Avalonia#10523
Part of #279

