### PR TITLE
Revert System.Memory to 4.5.4

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -13,7 +13,7 @@
     or intellisense will fail to load - see GH#298
     -->
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <Import Project="../../Props/NullableEnable.props" />


### PR DESCRIPTION
This change made impossible for people to edit xaml with our extension.  Reverting this change fixes the issue for me
Fixes: #313 