### PR TITLE
fix: Open Avalonia Xaml Designer on double-clicking on Errors list

### DIFF
--- a/AvaloniaVS.Shared/AvaloniaPackage.cs
+++ b/AvaloniaVS.Shared/AvaloniaPackage.cs
@@ -13,38 +13,38 @@ using Task = System.Threading.Tasks.Task;
 
 namespace AvaloniaVS
 {
-    [Guid(PackageGuidString)]
+    [Guid(Constants.PackageGuidString)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideEditorExtension(
         typeof(EditorFactory),
-        ".axaml",
+        "." + Constants.axaml,
         100,
         NameResourceID = 113,
         EditorFactoryNotify = true,
         ProjectGuid = VSConstants.UICONTEXT.CSharpProject_string,
-        DefaultName = Name)]
+        DefaultName = Constants.PackageName)]
     [ProvideEditorExtension(
         typeof(EditorFactory),
-        ".paml",
+        "." + Constants.paml,
         100,
         NameResourceID = 113,
         EditorFactoryNotify = true,
         ProjectGuid = VSConstants.UICONTEXT.CSharpProject_string,
-        DefaultName = Name)]
+        DefaultName = Constants.PackageName)]
     [ProvideEditorExtension(
         typeof(EditorFactory),
-        ".xaml",
+        "." + Constants.xaml,
         0x40,
         NameResourceID = 113,
         EditorFactoryNotify = true,
         ProjectGuid = VSConstants.UICONTEXT.CSharpProject_string,
-        DefaultName = Name)]
+        DefaultName = Constants.PackageName)]
     [ProvideEditorFactory(typeof(EditorFactory), 113, TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
     [ProvideEditorLogicalView(typeof(EditorFactory), LogicalViewID.Designer)]
-    [ProvideXmlEditorChooserDesignerView(Name,
-        "xaml",
+    [ProvideXmlEditorChooserDesignerView(Constants.PackageName,
+        Constants.xaml,
         LogicalViewID.Designer,
         10000,
         Namespace = "https://github.com/avaloniaui",
@@ -53,12 +53,22 @@ namespace AvaloniaVS
         DesignerLogicalViewEditor = typeof(EditorFactory),
         DebuggingLogicalViewEditor = typeof(EditorFactory),
         TextLogicalViewEditor = typeof(EditorFactory))]
-    [ProvideOptionPage(typeof(OptionsDialogPage), Name, "General", 113, 0, supportsAutomation: true)]
+    [ProvideXmlEditorChooserDesignerView(Constants.PackageName,
+        Constants.axaml,
+        LogicalViewID.Designer,
+        10000,
+        Namespace = "https://github.com/avaloniaui",
+        MatchExtensionAndNamespace = true,
+        CodeLogicalViewEditor = typeof(EditorFactory),
+        DesignerLogicalViewEditor = typeof(EditorFactory),
+        DebuggingLogicalViewEditor = typeof(EditorFactory),
+        TextLogicalViewEditor = typeof(EditorFactory))]
+    [ProvideOptionPage(typeof(OptionsDialogPage), Constants.PackageName, "General", 113, 0, supportsAutomation: true)]
+
+
+    [ProvideBindingPath]
     internal sealed class AvaloniaPackage : AsyncPackage
     {
-        public const string PackageGuidString = "865ba8d5-1180-4bf8-8821-345f72a4cb79";
-        public const string Name = "Avalonia Xaml Editor";
-
         public static SolutionService SolutionService { get; private set; }
 
         protected override async Task InitializeAsync(

--- a/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
+++ b/AvaloniaVS.Shared/AvaloniaVS.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EnumToIntConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EnumValuesConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\NotNullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Guids.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntelliSense\TextChangeAdapter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntelliSense\XamlCompletion.cs" />

--- a/AvaloniaVS.Shared/Commands/ViewCodeCommandHandler.cs
+++ b/AvaloniaVS.Shared/Commands/ViewCodeCommandHandler.cs
@@ -12,7 +12,7 @@ using Serilog;
 namespace AvaloniaVS.Shared.Commands
 {
     [Export(typeof(ICommandHandler))]
-    [ContentType("text")]
+    [ContentType(AvaloniaVS.Constants.xaml)]
     [Name("ViewCodeCommandHandler")]
     internal class ViewCodeCommandHandler : ICommandHandler<ViewCodeCommandArgs>
     {
@@ -44,7 +44,7 @@ namespace AvaloniaVS.Shared.Commands
                 if (!codeFile)
                     return false;
 
-                var wnd = codeProjectItem.Open(Constants.vsViewKindTextView);
+                var wnd = codeProjectItem.Open(EnvDTE.Constants.vsViewKindTextView);
                 wnd.Activate();
 
                 return true;

--- a/AvaloniaVS.Shared/Constants.cs
+++ b/AvaloniaVS.Shared/Constants.cs
@@ -1,0 +1,13 @@
+﻿namespace AvaloniaVS;
+
+internal static class Constants
+{
+    public const string PackageGuidString = "865ba8d5-1180-4bf8-8821-345f72a4cb79";
+    public const string PackageName = "Avalonia Xaml Editor";
+    public const string axaml = nameof(axaml);
+    public const string xaml = nameof(xaml);
+    public const string paml = nameof(paml);
+
+    public const string AvaloviaFactoryEditorGuidString = @"6D5344A2-2FCD-49DE-A09D-6A14FD1B1224";
+
+}

--- a/AvaloniaVS.Shared/IntelliSense/XamlTextViewCreationListener.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlTextViewCreationListener.cs
@@ -15,8 +15,11 @@ namespace AvaloniaVS.IntelliSense
     /// </summary>
     [Name("Avalonia XAML manupulator")]
     [ContentType("xml")]
+    [ContentType("axaml")]
+    [ContentType("xaml")]
     [Export(typeof(IWpfTextViewCreationListener))]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
+    [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
     internal sealed class XamlTextViewCreationListener : IWpfTextViewCreationListener
     {
         private readonly IServiceProvider _serviceProvider;

--- a/AvaloniaVS.Shared/Services/EditorFactory.cs
+++ b/AvaloniaVS.Shared/Services/EditorFactory.cs
@@ -18,6 +18,7 @@ namespace AvaloniaVS.Services
     /// Implements <see cref="IVsEditorFactory"/> to create <see cref="DesignerPane"/>s containing
     /// an Avalonia XAML designer.
     /// </summary>
+    [Guid(AvaloniaVS.Constants.AvaloviaFactoryEditorGuidString)]
     internal sealed class EditorFactory : IVsEditorFactory, IDisposable
     {
         private readonly AvaloniaPackage _package;


### PR DESCRIPTION
## Current behavior:

When double-clicking the error list entry, XML Designer opens instead of Avalonia Xaml Designer

## Expected behavior

When double-clicking the error list entry, XML Designer opens

## How simulate issue:

01. Create new Avalonia Project
02. Add Resource Dictionary named `icons.axaml'
03. Edit `App.axaml` like this
   ```xaml
   <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:ACTest"
              x:Class="ACTest.App">
     <Application.DataTemplates>
         <local:ViewLocator/>
     </Application.DataTemplates>
 
	 <Application.Resources>
		 <ResourceDictionary>
			 <ResourceDictionary.MergedDictionaries>
				 <ResourceInclude Source="Icons.axaml" />
			 </ResourceDictionary.MergedDictionaries>
		 </ResourceDictionary>
 	</Application.Resources>
	
     <Application.Styles>
         <FluentTheme/>
     </Application.Styles>
   </Application>
   ```

04. You can see in Errors list error like this:

     |Severity|Code|Description|Project|File|Line|Suppression State|
     |-|-|-|-|-|-|-|
     |Error|Unable to resolve XAML resource "avares://ACTest/Designer/Icons.axaml" in the "ACTest" assembly. Line 12, position 22.|ACTest|.\ACTest\ACTest\App.axaml|12|

05. do double-clicking
06. XML Designer will open
