### PR TITLE
feat: improved xmlns autocomplete

### DIFF
--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -207,6 +207,12 @@ namespace AvaloniaVS.IntelliSense
                         _textView.Caret.MoveTo(newCursorPos);
                     }
 
+                    // special-cased avoid TriggerCompletion
+                    if (selected.InsertionText == "xmlns:")
+                    {
+                        return true;
+                    }
+
                     // Ideally, we should only parse the current line of text, where the parser State would return
                     // 'None' if you're spreading control attributes out across multiple lines
                     // BUT, Selectors can span multiple lines (aggregates separated by ',') and this theory

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -498,7 +498,7 @@ public static class MetadataConverter
         types.Add(xDataType.Name, xDataType);
         types.Add(xCompiledBindings.Name, xCompiledBindings);
 
-        metadata.AddType("", new MetadataType("xmlns") { IsXamlDirective = true });
+        //metadata.AddType("", new MetadataType("xmlns") { IsXamlDirective = true });
     }
 
     private static void PostProcessTypes(Dictionary<string, MetadataType> types, Metadata metadata,

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -306,7 +306,7 @@ namespace CompletionEngineTests
         {
             var compl = GetCompletionsFor("<UserControl x").Completions;
 
-            Assert.Contains(compl, v => v.InsertText == "xmlns=\"\"");
+            Assert.Contains(compl, v => v.InsertText == "xmlns:");
         }
 
         [Fact]


### PR DESCRIPTION
## Before
![xmlns before](https://user-images.githubusercontent.com/12531229/226356057-0d9fc69e-1dac-4908-b8ba-d6140cead966.gif)

## After

![xmlns after](https://user-images.githubusercontent.com/12531229/226356845-371f0754-b2d2-456c-b76d-924a982f1eee.gif)

Part of #279
