### PR TITLE
feat: Ignore the Tab and Newline keys when a completion session is active in an expression

### DIFF
--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -242,6 +242,11 @@ namespace AvaloniaVS.IntelliSense
                             // {Binding path, RelativeSource={RelativeSource -> ...={RelativeSource |
                             if (parser.AttributeValue?.StartsWith("{") == true)
                             {
+                                // If press Tab or CR in expression ignore it in completation session
+                                if(c is '\t' or '\n')
+                                {
+                                    return true;
+                                }
                                 // To determine, we'll walk back the text from the cursor position
                                 // until we hit either something that isn't a character
                                 // If that's a {, we apply the space, otherwise we dont


### PR DESCRIPTION
## Before

![Expression Completationion Before](https://user-images.githubusercontent.com/12531229/226647748-1d884cf2-0a66-4654-a2c0-e67134225edf.gif)

## After

![Expression Completationion After](https://user-images.githubusercontent.com/12531229/226647926-59f4d92b-15f4-4d3e-a4f4-f02b150b0a09.gif)

Part of #279