### PR TITLE
Install Avalonia TemplateStudio extension when installing AvaloniaVS

### DIFF
--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Extension.vsext">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="overview.md">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/AvaloniaVS.VS2022/Extension.vsext
+++ b/AvaloniaVS.VS2022/Extension.vsext
@@ -1,0 +1,10 @@
+{
+  "description": "Read about creating extension packs at https://aka.ms/vsextpack",
+  "version": "1.0.0.0",
+  "extensions": [
+    {
+        "vsixId": "TemplateStudioForAvalonia.973b9e25-68ad-44b2-b375-9a775809cb97",
+        "name": "AvaloniaTemplateStudio"
+    }
+  ]
+}


### PR DESCRIPTION
From now when you install AvaloniaVS for VS 2022 you will get this dialog
![image](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/93cf1c74-ca1f-4710-a4ff-7369e228c9a8)
And you will get TS for Avalonia installed with AvaloniaVS