### PR TITLE
Fix intellisense attached property type mix match

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -532,7 +532,7 @@ public static class MetadataConverter
 
     private static void PreProcessTypes(Dictionary<string, MetadataType> types, Metadata metadata)
     {
-        MetadataType xDataType, xCompiledBindings, boolType, typeType;
+        MetadataType xDataType, xCompiledBindings, boolType, typeType, int32Type;
         var toAdd = new List<MetadataType>
         {
             (boolType = new MetadataType(typeof(bool).FullName!)
@@ -551,6 +551,17 @@ public static class MetadataConverter
             new MetadataType("Avalonia.Media.IBrush"),
             new MetadataType("Avalonia.Media.Imaging.IBitmap"),
             new MetadataType("Avalonia.Media.IImage"),
+            (int32Type = new MetadataType(typeof(int).FullName!)
+            {
+                HasHintValues = false,
+            }),
+            new MetadataType("System.Nullable`1<System.Int32>")
+            {
+                HasHintValues = false,
+                IsNullable = true,
+                UnderlyingType = int32Type,
+            },
+
         };
 
         foreach (var t in toAdd)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -267,15 +267,18 @@ public static class MetadataConverter
                                 IMethodInformation? setMethod = null;
                                 IMethodInformation? getMethod = null;
 
+                                var setMenthdName = $"Set{name}";
+                                var getMenthdName = $"Get{name}";
+
                                 foreach (var methodDef in typeDef.Methods)
                                 {
-                                    if (methodDef.Name.StartsWith("Set", StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
+                                    if (methodDef.Name.Equals(setMenthdName, StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
                                         && methodDef.Parameters.Count == 2)
                                     {
                                         setMethod = methodDef;
                                     }
                                     if (methodDef.IsStatic
-                                        && methodDef.Name.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
+                                        && methodDef.Name.Equals(getMenthdName, StringComparison.OrdinalIgnoreCase)
                                         && methodDef.IsPublic
                                         && methodDef.Parameters.Count == 1
                                         && !string.IsNullOrEmpty(methodDef.ReturnTypeFullName)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -267,18 +267,18 @@ public static class MetadataConverter
                                 IMethodInformation? setMethod = null;
                                 IMethodInformation? getMethod = null;
 
-                                var setMenthdName = $"Set{name}";
-                                var getMenthdName = $"Get{name}";
+                                var setMethodName = $"Set{name}";
+                                var getMethodName = $"Get{name}";
 
                                 foreach (var methodDef in typeDef.Methods)
                                 {
-                                    if (methodDef.Name.Equals(setMenthdName, StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
+                                    if (methodDef.Name.Equals(setMethodName, StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
                                         && methodDef.Parameters.Count == 2)
                                     {
                                         setMethod = methodDef;
                                     }
                                     if (methodDef.IsStatic
-                                        && methodDef.Name.Equals(getMenthdName, StringComparison.OrdinalIgnoreCase)
+                                        && methodDef.Name.Equals(getMethodName, StringComparison.OrdinalIgnoreCase)
                                         && methodDef.IsPublic
                                         && methodDef.Parameters.Count == 1
                                         && !string.IsNullOrEmpty(methodDef.ReturnTypeFullName)

--- a/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
+++ b/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
@@ -4,6 +4,7 @@ extern alias A2;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia.Controls;
 using Avalonia.Ide.CompletionEngine;
 using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 using Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
@@ -79,6 +80,22 @@ namespace CompletionEngineTests
             Assert.NotNull(ns);
             ns.TryGetValue(scenario.ClrType.Name, out var type);
             scenario.CheckAction(scenario.ClrType, type);
+        }
+
+        [Fact]
+        public void AttachedPropertySetterAndGetterMixmatch()
+        {
+            var clrType = typeof(Grid);
+            string nsName = "clr-namespace:" + clrType.Namespace + ";assembly=" + clrType.Assembly.GetName().Name;
+            var ns = Metadata.Namespaces[nsName];
+            Assert.NotNull(ns);
+            ns.TryGetValue(clrType.Name, out var type);
+            Assert.NotNull(type);
+
+            var property = type.Properties.SingleOrDefault(p=> p.Name == "Column");
+            Assert.NotNull(property);
+            Assert.True(property.IsAttached);
+            Assert.Equal("System.Int32", property.Type?.Name);
         }
 
         public static IEnumerable<object[]> GetCasese()


### PR DESCRIPTION
To simulate the issue, install the latest build from the repository and try adding any `Grid.Column` element, you can see that Intellisense proposes `True/False`.

The behavior depends on this fragment

https://github.com/AvaloniaUI/AvaloniaVS/blob/20556a572c1a8a0bc89da34b2e6f6dc4057402e9/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs#L270-L286

which returns the first static methods initialed by `Set` or `Get` instead of checking the full name.

This lines:

https://github.com/workgroupengineering/AvaloniaVS/blob/087973fd16142f327131f0107fb1bce73c0bd8e5/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs#L557-L566

is adding for check currect retutn type in test.
