### PR TITLE
Fix previewer mouse position when using screen scaling

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaPreviewer.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaPreviewer.xaml.cs
@@ -106,7 +106,7 @@ namespace AvaloniaVS.Views
 
         private double GetScaling()
         {
-            var result = Process?.Scaling ?? 1;
+            var result = (Process?.Scaling ?? 1) / VisualTreeHelper.GetDpi(this).DpiScaleX;
             return result > 0 ? result : 1;
         }
 


### PR DESCRIPTION
Since `Process.Scaling` is `user zoom * screen scaling` and the mouse position is already screen scaled, only the zoom must be kept.

Fixes #342