### PR TITLE
Fix events filtering in completion list

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -162,7 +162,7 @@ public class CompletionEngine
             if (t == null)
                 return Array.Empty<string>();
 
-            return t.Events.Where(n => n.IsAttached == attached && n.Name.StartsWith(propName)).Select(n => n.Name);
+            return t.Events.Where(n => n.IsAttached == attached && n.Name.StartsWith(propName, StringComparison.OrdinalIgnoreCase)).Select(n => n.Name);
         }
 
         public MetadataProperty? LookupProperty(string? typeName, string? propName)


### PR DESCRIPTION
Previously when you type a letter from which event name starts in lowercase you wouldn't get completions for events in a completion-list.

Before:
![Анимация1](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/882a44e7-f5c4-4161-a6a1-896fab57e7bc)

After:
![Анимация1](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/03a48c8d-08ad-445a-8093-d91000757c8a)
