### PR TITLE
Fix: Made desktop TargetPlatfromIdentifier check case insensitive

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -347,7 +347,11 @@ namespace AvaloniaVS.Views
 
                 bool IsValidOutput(ProjectOutputInfo output)
                 {
-                    return output.IsNetCore && output.RuntimeIdentifier != "browser-wasm" && (output.TargetPlatfromIdentifier == "" || output.TargetPlatfromIdentifier == "Windows" || output.TargetPlatfromIdentifier == "macos");
+                    return output.IsNetCore
+                        && output.RuntimeIdentifier != "browser-wasm"
+                        && (output.TargetPlatfromIdentifier == ""
+                            || string.Equals(output.TargetPlatfromIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(output.TargetPlatfromIdentifier, "macos", StringComparison.OrdinalIgnoreCase));
                 }
 
                 string GetXamlAssembly(ProjectOutputInfo output)


### PR DESCRIPTION
VS22 17.7.0 or some version between 17.6 and 17.7 changed the case of that value to lowercase causing the exe project to not be found.

Fix for at least one case of #191

## Legal
I am contributing this on behalf of Garmin ©. Our legal team needs me to disclose that we are contributing this code under the [MIT license](https://github.com/AvaloniaUI/Avalonia/blob/2ab5f8b8932e0acac078a58c30ff8db908d9a9d8/licence.md) that this project used at the time of contribution.