### PR TITLE
Fix extension incompatibility with VS older than 17.7

### DIFF
--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -82,16 +82,16 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Remote.Protocol" Version="11.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>4.7.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.7.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>4.7.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>4.7.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
       <Version>15.8.243</Version>


### PR DESCRIPTION
Roslyn nugets were incompatible with older VS versions
https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md#versioning 
Fixes #399 