### PR TITLE
fix: When tagName is not Empty do not show XML Comment and auto close tag

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -260,22 +260,24 @@ public class CompletionEngine
             }
             else
             {
-                if (state.GetParentTagName(1) is string parentTag)
+                if (tagName.Length == 0)
                 {
-                    if (!state.IsInClosingTag)
+                    if (state.GetParentTagName(1) is string parentTag)
                     {
-                        completions.Add(new Completion("/" + parentTag + ">", CompletionKind.Class, priority: 0));
-                    }
-                    if (parentTag.IndexOf('.') == -1)
-                    {
-                        completions.Add(new Completion(parentTag, $"{parentTag}.", CompletionKind.Class, priority: 1)
+                        if (!state.IsInClosingTag)
                         {
-                            TriggerCompletionAfterInsert = true,
-                        });
+                            completions.Add(new Completion("/" + parentTag + ">", CompletionKind.Class, priority: 0));
+                        }
+                        if (parentTag.IndexOf('.') == -1)
+                        {
+                            completions.Add(new Completion(parentTag, $"{parentTag}.", CompletionKind.Class, priority: 1)
+                            {
+                                TriggerCompletionAfterInsert = true,
+                            });
+                        }
                     }
+                    completions.Add(new Completion("!--", "!---->", CompletionKind.Comment) { RecommendedCursorOffset = 3 });
                 }
-                completions.Add(new Completion("!--", "!---->", CompletionKind.Comment) { RecommendedCursorOffset = 3 });
-
                 completions.AddRange(Helper.FilterTypes(tagName)
                     .Where(kvp=>!kvp.Value.IsAbstract)
                     .Select(kvp =>

--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -139,9 +139,9 @@ namespace CompletionEngineTests
         {
             var compl = GetCompletionsFor("<DataTemplate");
 
-            Assert.Equal(5, compl.Completions.Count);
-            Assert.Equal("DataTemplate", compl.Completions[3].DisplayText);
-            Assert.Equal("DataTemplates", compl.Completions[4].DisplayText);
+            Assert.Equal(2, compl.Completions.Count);
+            Assert.Equal("DataTemplate", compl.Completions[0].DisplayText);
+            Assert.Equal("DataTemplates", compl.Completions[1].DisplayText);
         }
 
         [Fact]


### PR DESCRIPTION
## Before

![Before](https://github.com/AvaloniaUI/AvaloniaVS/assets/12531229/17893c8a-535d-4de0-9a55-eb2b84e7053f)

## After

![after](https://github.com/AvaloniaUI/AvaloniaVS/assets/12531229/cc37a9b7-1738-446d-8b18-72a219aa249d)
