### PR TITLE
Intellisense support for BCL types

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -568,7 +568,7 @@ namespace AvaloniaVS.Views
                 {
                     metadataLoad = Task.Run(() =>
                                     {
-                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider());
+                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider(), new AvaloniaCompilationAssemblyProvider());
                                         return metadataReader.GetForTargetAssembly(intermediateOutputPath);
                                     });
                     _metadataCache[intermediateOutputPath] = metadataLoad;

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -16,6 +16,7 @@ using AvaloniaVS.Models;
 using AvaloniaVS.Services;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Threading;
@@ -465,11 +466,11 @@ namespace AvaloniaVS.Views
             var assemblyPath = SelectedTarget?.XamlAssembly;
             var executablePath = SelectedTarget?.ExecutableAssembly;
             var hostAppPath = SelectedTarget?.HostApp;
-            var isNetFx = SelectedTarget?.IsNetFramework; 
+            var isNetFx = SelectedTarget?.IsNetFramework;
 
             if (assemblyPath != null && executablePath != null && hostAppPath != null && isNetFx != null)
             {
-                RebuildMetadata(assemblyPath, executablePath);
+                RebuildMetadata(assemblyPath);
 
                 try
                 {
@@ -518,22 +519,23 @@ namespace AvaloniaVS.Views
             Log.Logger.Verbose("Finished AvaloniaDesigner.StartProcessAsync()");
         }
 
-        private void RebuildMetadata(string assemblyPath, string executablePath)
+        private void RebuildMetadata(string assemblyPath)
         {
-            assemblyPath = assemblyPath ?? SelectedTarget?.XamlAssembly;
-            executablePath = executablePath ?? SelectedTarget?.ExecutableAssembly;
+            assemblyPath ??= SelectedTarget?.XamlAssembly;
 
-            if (assemblyPath != null && executablePath != null)
+            if (assemblyPath != null && SelectedTarget?.Project != null)
             {
                 var buffer = _editor.TextView.TextBuffer;
                 var metadata = buffer.Properties.GetOrCreateSingletonProperty(
                     typeof(XamlBufferMetadata),
                     () => new XamlBufferMetadata());
                 buffer.Properties["AssemblyName"] = Path.GetFileNameWithoutExtension(assemblyPath);
-
+                var storage = GetMSBuildPropertyStorage(SelectedTarget.Project);
+                string intermediateOutputPath = GetMSBuildProperty("MSBuildProjectDirectory", storage) + "\\"
+                    + GetMSBuildProperty("IntermediateOutputPath", storage) + "Avalonia\\references";
                 if (metadata.CompletionMetadata == null || metadata.NeedInvalidation)
                 {
-                    CreateCompletionMetadataAsync(executablePath, metadata).FireAndForget();
+                    CreateCompletionMetadataAsync(intermediateOutputPath, metadata).FireAndForget();
                 }
             }
         }
@@ -541,7 +543,7 @@ namespace AvaloniaVS.Views
         private static Dictionary<string, Task<Metadata>> _metadataCache;
 
         private static async Task CreateCompletionMetadataAsync(
-            string executablePath,
+            string intermediateOutputPath,
             XamlBufferMetadata target)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -554,7 +556,7 @@ namespace AvaloniaVS.Views
                 dte.Events.BuildEvents.OnBuildBegin += (s, e) => _metadataCache.Clear();
             }
 
-            Log.Logger.Verbose("Started AvaloniaDesigner.CreateCompletionMetadataAsync() for {ExecutablePath}", executablePath);
+            Log.Logger.Verbose("Started AvaloniaDesigner.CreateCompletionMetadataAsync() for {ExecutablePath}", intermediateOutputPath);
 
             try
             {
@@ -562,14 +564,14 @@ namespace AvaloniaVS.Views
 
                 Task<Metadata> metadataLoad;
 
-                if (!_metadataCache.TryGetValue(executablePath, out metadataLoad))
+                if (!_metadataCache.TryGetValue(intermediateOutputPath, out metadataLoad))
                 {
                     metadataLoad = Task.Run(() =>
                                     {
                                         var metadataReader = new MetadataReader(new DnlibMetadataProvider());
-                                        return metadataReader.GetForTargetAssembly(executablePath);
+                                        return metadataReader.GetForTargetAssembly(intermediateOutputPath);
                                     });
-                    _metadataCache[executablePath] = metadataLoad;
+                    _metadataCache[intermediateOutputPath] = metadataLoad;
                 }
 
                 target.CompletionMetadata = await metadataLoad;
@@ -578,7 +580,7 @@ namespace AvaloniaVS.Views
 
                 sw.Stop();
 
-                Log.Logger.Verbose("Finished AvaloniaDesigner.CreateCompletionMetadataAsync() took {Time} for {ExecutablePath}", sw.Elapsed, executablePath);
+                Log.Logger.Verbose("Finished AvaloniaDesigner.CreateCompletionMetadataAsync() took {Time} for {ExecutablePath}", sw.Elapsed, intermediateOutputPath);
             }
             catch (Exception ex)
             {
@@ -839,6 +841,32 @@ namespace AvaloniaVS.Views
             {
                 return await reader.ReadToEndAsync();
             }
+        }
+
+        private IVsBuildPropertyStorage GetMSBuildPropertyStorage(Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            IVsSolution solution = (IVsSolution)ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution));
+
+            int hr = solution.GetProjectOfUniqueName(project.FullName, out var hierarchy);
+            System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(hr);
+
+            return hierarchy as IVsBuildPropertyStorage;
+        }
+
+        private string GetMSBuildProperty(string key, IVsBuildPropertyStorage storage)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            int hr = storage.GetPropertyValue(key, null, (uint)_PersistStorageType.PST_USER_FILE, out var value);
+            int E_XML_ATTRIBUTE_NOT_FOUND = unchecked((int)0x8004C738);
+
+            // ignore this HR, it means that there's no value for this key
+            if (hr != E_XML_ATTRIBUTE_NOT_FOUND)
+            {
+                System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(hr);
+            }
+
+            return value;
         }
     }
 }

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -568,8 +568,8 @@ namespace AvaloniaVS.Views
                 {
                     metadataLoad = Task.Run(() =>
                                     {
-                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider(), new AvaloniaCompilationAssemblyProvider());
-                                        return metadataReader.GetForTargetAssembly(intermediateOutputPath);
+                                        var metadataReader = new MetadataReader(new DnlibMetadataProvider());
+                                        return metadataReader.GetForTargetAssembly(new AvaloniaCompilationAssemblyProvider(intermediateOutputPath));
                                     });
                     _metadataCache[intermediateOutputPath] = metadataLoad;
                 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
@@ -6,9 +6,18 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
 {
     public class AvaloniaCompilationAssemblyProvider : IAssemblyProvider
     {
-        public IEnumerable<string> GetAssemblies(string path)
+        private readonly string _path;
+
+        public AvaloniaCompilationAssemblyProvider(string path)
         {
-            return File.ReadAllText(path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentNullException(nameof(path));
+            _path = path;
+        }
+
+        public IEnumerable<string> GetAssemblies()
+        {
+            return File.ReadAllText(_path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
+{
+    public class AvaloniaCompilationAssemblyProvider : IAssemblyProvider
+    {
+        public IEnumerable<string> GetAssemblies(string path)
+        {
+            return File.ReadAllText(path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
+{
+    public interface IAssemblyProvider
+    {
+        IEnumerable<string> GetAssemblies(string path);
+    }
+}

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyProvider.cs
@@ -4,6 +4,6 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
 {
     public interface IAssemblyProvider
     {
-        IEnumerable<string> GetAssemblies(string path);
+        IEnumerable<string> GetAssemblies();
     }
 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 
@@ -16,16 +15,7 @@ public class MetadataReader
 
     private static IEnumerable<string> GetAssemblies(string path)
     {
-        if (Path.GetDirectoryName(path) is not { } directory)
-        {
-            return Array.Empty<string>();
-        }
-
-        var depsPath = Path.Combine(directory,
-            Path.GetFileNameWithoutExtension(path) + ".deps.json");
-        if (File.Exists(depsPath))
-            return DepsJsonAssemblyListLoader.ParseFile(depsPath);
-        return Directory.GetFiles(directory).Where(f => f.EndsWith(".dll") || f.EndsWith(".exe"));
+        return File.ReadAllText(path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
     }
 
     public Metadata? GetForTargetAssembly(string path)
@@ -33,7 +23,7 @@ public class MetadataReader
         if (!File.Exists(path))
             return null;
 
-        using var session = _provider.GetMetadata(MetadataReader.GetAssemblies(path));
+        using var session = _provider.GetMetadata(GetAssemblies(path));
         return MetadataConverter.ConvertMetadata(session);
     }
 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
@@ -1,26 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-
-namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+﻿namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 
 public class MetadataReader
 {
     private readonly IMetadataProvider _provider;
-    private readonly IAssemblyProvider _assemblyProvider;
 
-    public MetadataReader(IMetadataProvider provider, IAssemblyProvider assemblyProvider)
+    public MetadataReader(IMetadataProvider provider)
     {
         _provider = provider;
-        _assemblyProvider = assemblyProvider;
     }
 
-    public Metadata? GetForTargetAssembly(string path)
+    public Metadata? GetForTargetAssembly(IAssemblyProvider assemblyProvider)
     {
-        if (!File.Exists(path))
-            return null;
-
-        using var session = _provider.GetMetadata(_assemblyProvider.GetAssemblies(path));
+        using var session = _provider.GetMetadata(assemblyProvider.GetAssemblies());
         return MetadataConverter.ConvertMetadata(session);
     }
 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataReader.cs
@@ -7,15 +7,12 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 public class MetadataReader
 {
     private readonly IMetadataProvider _provider;
+    private readonly IAssemblyProvider _assemblyProvider;
 
-    public MetadataReader(IMetadataProvider provider)
+    public MetadataReader(IMetadataProvider provider, IAssemblyProvider assemblyProvider)
     {
         _provider = provider;
-    }
-
-    private static IEnumerable<string> GetAssemblies(string path)
-    {
-        return File.ReadAllText(path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+        _assemblyProvider = assemblyProvider;
     }
 
     public Metadata? GetForTargetAssembly(string path)
@@ -23,7 +20,7 @@ public class MetadataReader
         if (!File.Exists(path))
             return null;
 
-        using var session = _provider.GetMetadata(GetAssemblies(path));
+        using var session = _provider.GetMetadata(_assemblyProvider.GetAssemblies(path));
         return MetadataConverter.ConvertMetadata(session);
     }
 }

--- a/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
+++ b/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
@@ -211,7 +211,7 @@ namespace CompletionEngineTests
             nameof(Models.InternalClass.PublicProperty),
         };
 
-        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider())
+        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider(), new FolderAssemblyProvider())
             .GetForTargetAssembly(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName);
     }
 }

--- a/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
+++ b/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
@@ -211,7 +211,7 @@ namespace CompletionEngineTests
             nameof(Models.InternalClass.PublicProperty),
         };
 
-        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider(), new FolderAssemblyProvider())
-            .GetForTargetAssembly(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName);
+        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider())
+            .GetForTargetAssembly(new FolderAssemblyProvider(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName));
     }
 }

--- a/tests/CompletionEngineTests/XamlCompletionTestBase.cs
+++ b/tests/CompletionEngineTests/XamlCompletionTestBase.cs
@@ -12,15 +12,22 @@ namespace CompletionEngineTests
 {
     public class FolderAssemblyProvider : IAssemblyProvider
     {
-        public IEnumerable<string> GetAssemblies(string path)
+        private readonly string _path;
+
+        public FolderAssemblyProvider(string path)
         {
-            if (Path.GetDirectoryName(path) is not { } directory)
+            _path = path;
+        }
+
+        public IEnumerable<string> GetAssemblies()
+        {
+            if (Path.GetDirectoryName(_path) is not { } directory)
             {
                 return Array.Empty<string>();
             }
 
             var depsPath = Path.Combine(directory,
-                Path.GetFileNameWithoutExtension(path) + ".deps.json");
+                Path.GetFileNameWithoutExtension(_path) + ".deps.json");
             if (File.Exists(depsPath))
                 return DepsJsonAssemblyListLoader.ParseFile(depsPath);
             return Directory.GetFiles(directory).Where(f => f.EndsWith(".dll") || f.EndsWith(".exe"));
@@ -35,8 +42,8 @@ namespace CompletionEngineTests
         xmlns:local='clr-namespace:CompletionEngineTests.Models;assembly=CompletionEngineTests'>".Replace("'", "\"");
 
 
-        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider(), new FolderAssemblyProvider())
-            .GetForTargetAssembly(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName);
+        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider())
+            .GetForTargetAssembly(new FolderAssemblyProvider(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName));
 
         CompletionSet TransformCompletionSet(CompletionSet set)
         {


### PR DESCRIPTION
Previously when getting completion metadata we were taking dll's from bin folder. And usually framework dll-s are not stored in the bin folder and that's the reason why completions for BCL types were not working. Now we get full dll-s list from obj\Avalonia\references file which stores all paths to dll-s used for a compilation and parse them to get metadata
Fixes #353 