### PR TITLE
Speed up metadata parsing

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/DnlibMetadataProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/DnlibMetadataProvider.cs
@@ -17,12 +17,44 @@ public class DnlibMetadataProvider : IMetadataProvider
 
 internal class DnlibMetadataProviderSession : IMetadataReaderSession
 {
+    private readonly Dictionary<ITypeDefOrRef, ITypeDefOrRef> _baseTypes = new Dictionary<ITypeDefOrRef, ITypeDefOrRef>();
+    private readonly Dictionary<ITypeDefOrRef, TypeDef> _baseTypeDefs = new Dictionary<ITypeDefOrRef, TypeDef>();
     public string TargetAssemblyName { get; private set; }
     public IEnumerable<IAssemblyInformation> Assemblies { get; }
     public DnlibMetadataProviderSession(string[] directoryPath)
     {
         TargetAssemblyName = System.Reflection.AssemblyName.GetAssemblyName(directoryPath[0]).ToString();
-        Assemblies = LoadAssemblies(directoryPath).Select(a => new AssemblyWrapper(a)).ToList();
+        Assemblies = LoadAssemblies(directoryPath).Select(a => new AssemblyWrapper(a, this)).ToList();
+    }
+
+    public TypeDef? GetBaseTypeDef(ITypeDefOrRef type)
+    {
+        if (type == null)
+        {
+            return null;
+        }
+
+        if (_baseTypeDefs.TryGetValue(type, out var baseType))
+        {
+            return baseType;
+        }
+        else
+        {
+            return _baseTypeDefs[type] = GetBaseType(type).ResolveTypeDef();
+        }
+    }
+
+    public ITypeDefOrRef GetBaseType(ITypeDefOrRef type)
+    {
+        if (_baseTypes.TryGetValue(type, out var baseType))
+        {
+            return baseType;
+        }
+        else
+        {
+            return _baseTypes[type] = type.GetBaseType();
+        }
+
     }
 
     private static List<AssemblyDef> LoadAssemblies(string[] lst)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/DnlibMetadataProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/DnlibMetadataProvider.cs
@@ -27,7 +27,7 @@ internal class DnlibMetadataProviderSession : IMetadataReaderSession
         Assemblies = LoadAssemblies(directoryPath).Select(a => new AssemblyWrapper(a, this)).ToList();
     }
 
-    public TypeDef? GetBaseTypeDef(ITypeDefOrRef type)
+    public TypeDef? GetTypeDef(ITypeDefOrRef type)
     {
         if (type == null)
         {
@@ -40,7 +40,7 @@ internal class DnlibMetadataProviderSession : IMetadataReaderSession
         }
         else
         {
-            return _baseTypeDefs[type] = GetBaseType(type).ResolveTypeDef();
+            return _baseTypeDefs[type] = type.ResolveTypeDef();
         }
     }
 

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -64,7 +64,7 @@ internal class TypeWrapper : ITypeInformation
     public string Name => _type.Name;
     public string AssemblyQualifiedName { get; }
     public string Namespace => _type.Namespace;
-    public ITypeInformation? GetBaseType() => FromDef(_session.GetBaseTypeDef(_session.GetBaseType(_type)), _session);
+    public ITypeInformation? GetBaseType() => FromDef(_session.GetTypeDef(_session.GetBaseType(_type)), _session);
 
     public IEnumerable<IEventInformation> Events => _type.Events.Select(e => new EventWrapper(e));
 

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -10,10 +10,12 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
 internal class AssemblyWrapper : IAssemblyInformation
 {
     private readonly AssemblyDef _asm;
+    private readonly DnlibMetadataProviderSession _session;
 
-    public AssemblyWrapper(AssemblyDef asm)
+    public AssemblyWrapper(AssemblyDef asm, DnlibMetadataProviderSession session)
     {
         _asm = asm;
+        _session = session;
     }
 
     public string Name => _asm.Name;
@@ -22,7 +24,7 @@ internal class AssemblyWrapper : IAssemblyInformation
         => _asm.GetFullNameWithPublicKeyToken();
 
     public IEnumerable<ITypeInformation> Types
-        => _asm.Modules.SelectMany(m => m.Types).Select(TypeWrapper.FromDef).Where(t => t is not null)!;
+        => _asm.Modules.SelectMany(m => m.Types).Select(x => TypeWrapper.FromDef(x, _session)).Where(t => t is not null)!;
 
     public IEnumerable<ICustomAttributeInformation> CustomAttributes
         => _asm.CustomAttributes.Select(a => new CustomAttributeWrapper(a));
@@ -45,15 +47,16 @@ internal class AssemblyWrapper : IAssemblyInformation
 internal class TypeWrapper : ITypeInformation
 {
     private readonly TypeDef _type;
+    private readonly DnlibMetadataProviderSession _session;
 
-    public static TypeWrapper? FromDef(TypeDef def) => def == null ? null : new TypeWrapper(def);
+    public static TypeWrapper? FromDef(TypeDef? def, DnlibMetadataProviderSession session) => def == null ? null : new TypeWrapper(def, session);
 
-    private TypeWrapper(TypeDef type)
+    private TypeWrapper(TypeDef type, DnlibMetadataProviderSession session)
     {
         if (type == null)
             throw new ArgumentNullException();
         _type = type;
-
+        _session = session;
         AssemblyQualifiedName = _type.AssemblyQualifiedName;
     }
 
@@ -61,13 +64,13 @@ internal class TypeWrapper : ITypeInformation
     public string Name => _type.Name;
     public string AssemblyQualifiedName { get; }
     public string Namespace => _type.Namespace;
-    public ITypeInformation? GetBaseType() => FromDef(_type.GetBaseType().ResolveTypeDef());
+    public ITypeInformation? GetBaseType() => FromDef(_session.GetBaseTypeDef(_session.GetBaseType(_type)), _session);
 
     public IEnumerable<IEventInformation> Events => _type.Events.Select(e => new EventWrapper(e));
 
     public IEnumerable<IMethodInformation> Methods => _type.Methods.Select(m => new MethodWrapper(m));
 
-    public IEnumerable<IFieldInformation> Fields => _type.Fields.Select(f => new FieldWrapper(f));
+    public IEnumerable<IFieldInformation> Fields => _type.Fields.Select(f => new FieldWrapper(f, _session));
 
     public IEnumerable<IPropertyInformation> Properties => _type.Properties
         //Filter indexer properties
@@ -122,7 +125,7 @@ internal class TypeWrapper : ITypeInformation
     }
     public override string ToString() => Name;
     public IEnumerable<ITypeInformation> NestedTypes =>
-        _type.HasNestedTypes ? _type.NestedTypes.Select(t => new TypeWrapper(t)) : Array.Empty<TypeWrapper>();
+        _type.HasNestedTypes ? _type.NestedTypes.Select(t => new TypeWrapper(t, _session)) : Array.Empty<TypeWrapper>();
 
     public IEnumerable<(ITypeInformation Type, string Name)> TemplateParts
     {
@@ -134,7 +137,7 @@ internal class TypeWrapper : ITypeInformation
             foreach (var attr in attributes)
             {
                 var name = attr.ConstructorArguments[0].Value.ToString()!;
-                ITypeInformation type = TypeWrapper.FromDef(((ClassSig)attr.ConstructorArguments[1].Value).TypeDef)!;
+                ITypeInformation type = FromDef(((ClassSig)attr.ConstructorArguments[1].Value).TypeDef, _session)!;
                 yield return (type, name);
             }
         }
@@ -280,7 +283,7 @@ internal class PropertyWrapper : IPropertyInformation
 
 internal class FieldWrapper : IFieldInformation
 {
-    public FieldWrapper(FieldDef f)
+    public FieldWrapper(FieldDef f, DnlibMetadataProviderSession session)
     {
         IsStatic = f.IsStatic;
         IsPublic = f.IsPublic || f.IsAssembly;
@@ -296,7 +299,7 @@ internal class FieldWrapper : IFieldInformation
                 isRoutedEvent = true;
                 break;
             }
-            t = t.GetBaseType();
+            t = session.GetBaseType(t);
         }
 
         IsRoutedEvent = isRoutedEvent;


### PR DESCRIPTION
Previously parsing of the metadata for avalonia MVVM template took approximately ~30s. While metadata is being parsed Intellisense won't work.  
Now it takes around 10 times less time.
Before:
![image](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/b74ad616-1278-4b0d-a0b9-02e0ef61b433)

After:
![image](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/1dadaa6d-29f1-4c78-be86-5153595ed1e9)
