### PR TITLE
Fix .NET 8 SDK Artifacts output layout

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
@@ -17,7 +17,19 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
 
         public IEnumerable<string> GetAssemblies()
         {
-            return File.ReadAllText(_path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            try
+            {
+                return File.ReadAllText(_path).Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            catch (Exception ex) when
+                (ex is DirectoryNotFoundException || ex is FileNotFoundException)
+            {
+                return Array.Empty<string>();
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to read file '{_path}'.", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output


```
_path = "Z:\abcd\Mobius\src\Mobius.Windows\Z:\abcd\Mobius\src\artifacts\obj\Mobius.Windows\debug_net8.0-windows10.0.19041.0\Avalonia\references";

System.NotSupportedException: 不支持给定路径的格式。
   在 System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
   在 System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   在 System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   在 System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean checkHost)
   在 System.IO.File.InternalReadAllText(String path, Encoding encoding, Boolean checkHost)
   在 Avalonia.Ide.CompletionEngine.AssemblyMetadata.AvaloniaCompilationAssemblyProvider.GetAssemblies()
   --- 内部异常堆栈跟踪的结尾 ---
   在 Avalonia.Ide.CompletionEngine.AssemblyMetadata.AvaloniaCompilationAssemblyProvider.GetAssemblies()
   在 Avalonia.Ide.CompletionEngine.AssemblyMetadata.MetadataReader.GetForTargetAssembly(IAssemblyProvider assemblyProvider)
   在 System.Threading.Tasks.Task`1.InnerInvoke()
   在 System.Threading.Tasks.Task.Execute()
--- 引发异常的上一位置中堆栈跟踪的末尾 ---
   在 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   在 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   在 AvaloniaVS.Views.AvaloniaDesigner.<CreateCompletionMetadataAsync>d__61.MoveNext() 位置 C:\Repos\AvaloniaVS\AvaloniaVS.Shared\Views\AvaloniaDesigner.xaml.cs:行号 577
11:18:00.545 [Information] 58000 Connection initialized

```