### PR TITLE
Fix completions filtering

### DIFF
--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -100,7 +100,7 @@ namespace AvaloniaVS.IntelliSense
                     return VSConstants.S_OK;
                 }
 
-                if (HandleSessionUpdate(c))
+                if (HandleSessionUpdate())
                 {
                     return VSConstants.S_OK;
                 }
@@ -141,7 +141,7 @@ namespace AvaloniaVS.IntelliSense
             return false;
         }
 
-        private bool HandleSessionUpdate(char _)
+        private bool HandleSessionUpdate()
         {
             if (_session != null && !_session.IsDismissed)
             {

--- a/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
+++ b/AvaloniaVS.Shared/IntelliSense/XamlCompletionCommandHandler.cs
@@ -141,16 +141,11 @@ namespace AvaloniaVS.IntelliSense
             return false;
         }
 
-        private bool HandleSessionUpdate(char c)
+        private bool HandleSessionUpdate(char _)
         {
-            // Update the filter if there is a deletion.
-            if (c == '\b')
+            if (_session != null && !_session.IsDismissed)
             {
-                if (_session != null && !_session.IsDismissed)
-                {
-                    _session.Filter();
-                }
-
+                _session.Filter();
                 return true;
             }
 


### PR DESCRIPTION
Previously filtering of the completion list happened only when removing the characters. Now every time you enter the character completion list will be filtered according to the input
Before:
![Анимация1](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/ab151fe0-a02f-44aa-a239-f99ac22b555d)

After:
![Анимация1](https://github.com/AvaloniaUI/AvaloniaVS/assets/53405089/ff38fdb6-bd43-4180-abca-8e5cb1d8ee17)
