### PR TITLE
fix(Previewer): `Fit All` using ViewportSize insteand of ActualWidth/ActualHeight

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -435,10 +435,15 @@ namespace AvaloniaVS.Views
             {
                 if (Process.IsReady && Process.Bitmap != null)
                 {
-                    double x = previewer.ActualWidth / (Process.Bitmap.Width / Process.Scaling);
-                    double y = previewer.ActualHeight / (Process.Bitmap.Height / Process.Scaling);
+                    var size = previewer.GetViewportSize(10);
+                    double x = size.Width / (Process.Bitmap.Width / Process.Scaling);
+                    double y = size.Height / (Process.Bitmap.Height / Process.Scaling);
 
-                    ZoomLevel = string.Format(CultureInfo.InvariantCulture, "{0}%", Math.Round(Math.Min(x, y), 2, MidpointRounding.ToEven) * 100);
+                    ZoomLevel = null;
+                    Dispatcher.BeginInvoke(() =>
+                        ZoomLevel = string.Format(CultureInfo.InvariantCulture, "{0}%", Math.Round(Math.Min(x, y), 2, MidpointRounding.ToEven) * 100),
+                        System.Windows.Threading.DispatcherPriority.Background);
+                    
                 }
                 else
                 {


### PR DESCRIPTION
## Current behavior

When call `Fit All` , the extremes of the view are not visible because they are covered by the scrollbars.


## Expected behavior

View displayed all.

## What PR does

instead of using Previewer ActualWidth/ActualHeight , get the ViewportSize of the ScrollViewer present in the Previewer and add a padding.