### PR TITLE
feat: Show properties of binded object before `Binding` members.

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -743,7 +743,7 @@ public class CompletionEngine
             {
                 foreach (var propertyName in MetadataHelper.FilterPropertyNames(filterType, filter, false, false))
                 {
-                    yield return new Completion(propertyName, fmtInsertText?.Invoke(propertyName) ?? propertyName, propertyName, CompletionKind.DataProperty);
+                    yield return new Completion(propertyName, fmtInsertText?.Invoke(propertyName) ?? propertyName, propertyName, CompletionKind.DataProperty, Priority:254);
                 }
             }
         }


### PR DESCRIPTION

![immagine](https://github.com/AvaloniaUI/AvaloniaVS/assets/12531229/c8a70b31-9317-48b4-b4cc-4a0a5fa4e9a2)

