### PR TITLE
Fix typos; Add concat-like `Metadata.AddMetadata(Metadata)`; Add in-line docs for `AvaloniaCompilationAssemblyProvider` usage

### DIFF
--- a/AvaloniaVS.Shared/Models/ProjectOutputInfo.cs
+++ b/AvaloniaVS.Shared/Models/ProjectOutputInfo.cs
@@ -27,8 +27,6 @@ namespace AvaloniaVS.Models
         /// </summary>
         public string RuntimeIdentifier { get; }
 
-        [Obsolete($"Member name mispelled. Use {nameof(TargetPlatformIdentifier)} instead.")]
-        public string TargetPlatfromIdentifier => TargetPlatformIdentifier;
         public string TargetPlatformIdentifier { get; }
 
         /// <summary>

--- a/AvaloniaVS.Shared/Models/ProjectOutputInfo.cs
+++ b/AvaloniaVS.Shared/Models/ProjectOutputInfo.cs
@@ -1,4 +1,4 @@
-﻿using AvaloniaVS.Utils;
+using AvaloniaVS.Utils;
 
 namespace AvaloniaVS.Models
 {
@@ -27,7 +27,9 @@ namespace AvaloniaVS.Models
         /// </summary>
         public string RuntimeIdentifier { get; }
 
-        public string TargetPlatfromIdentifier { get; }
+        [Obsolete($"Member name mispelled. Use {nameof(TargetPlatformIdentifier)} instead.")]
+        public string TargetPlatfromIdentifier => TargetPlatformIdentifier;
+        public string TargetPlatformIdentifier { get; }
 
         /// <summary>
         /// Gets the full path to the Avalonia.Designer.HostApp.dll to use.
@@ -50,14 +52,14 @@ namespace AvaloniaVS.Models
         public bool IsNetStandard => FrameworkInfoUtils.IsNetStandard(TargetFrameworkIdentifier);
 
         public ProjectOutputInfo(
-            string targetAssembly, string targetFramework, string targetFrameworkIdentifier, string hostApp, string runtimeIdentifier, string targetPlatfromIdentifier)
+            string targetAssembly, string targetFramework, string targetFrameworkIdentifier, string hostApp, string runtimeIdentifier, string TargetPlatformIdentifier)
         {
             TargetAssembly = targetAssembly;
             TargetFramework = targetFramework;
             TargetFrameworkIdentifier = targetFrameworkIdentifier;
             HostApp = hostApp;
             RuntimeIdentifier = runtimeIdentifier;
-            TargetPlatfromIdentifier = targetPlatfromIdentifier;
+            TargetPlatformIdentifier = TargetPlatformIdentifier;
         }
     }
 }

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -100,7 +100,7 @@ namespace AvaloniaVS.Views
         private bool _disposed;
         private double _scaling = 1;
         private AvaloniaDesignerView _unPausedView;
-        private bool _buidRequired;
+        private bool _buildRequired;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AvaloniaDesigner"/> class.
@@ -350,9 +350,9 @@ namespace AvaloniaVS.Views
                 {
                     return (output.IsNetCore || output.IsNetFramework)
                         && output.RuntimeIdentifier != "browser-wasm"
-                        && (output.TargetPlatfromIdentifier == ""
-                            || string.Equals(output.TargetPlatfromIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
-                            || string.Equals(output.TargetPlatfromIdentifier, "macos", StringComparison.OrdinalIgnoreCase));
+                        && (output.TargetPlatformIdentifier == ""
+                            || string.Equals(output.TargetPlatformIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(output.TargetPlatformIdentifier, "macos", StringComparison.OrdinalIgnoreCase));
                 }
 
                 string GetXamlAssembly(ProjectOutputInfo output)
@@ -490,7 +490,7 @@ namespace AvaloniaVS.Views
                 }
                 catch (FileNotFoundException ex)
                 {
-                    _buidRequired = true;
+                    _buildRequired = true;
                     ShowError("Build Required", ex.Message);
                     Log.Logger.Debug(ex, "StartAsync could not find executable");
                 }
@@ -503,7 +503,7 @@ namespace AvaloniaVS.Views
                 {
                     _startingProcess.Release();
                 }
-                _buidRequired = false;
+                _buildRequired = false;
             }
             else
             {
@@ -654,7 +654,7 @@ namespace AvaloniaVS.Views
             errorIndicator.Visibility = Visibility.Visible;
             errorHeading.Text = heading;
             errorMessage.Text = message;
-            if (_buidRequired == true)
+            if (_buildRequired == true)
             {
                 previewer.buildButton.Visibility = Visibility.Visible;
             }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/AvaloniaCompilationAssemblyProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -8,6 +8,21 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
     {
         private readonly string _path;
 
+        /// <summary>
+        /// Create a new instance of <see cref="AvaloniaCompilationAssemblyProvider"/>—an implementation of <see cref="IAssemblyProvider"/>.
+        /// </summary>
+        /// <param name="path">
+        /// <para>
+        /// The full path of a plaint text file.<br/>
+        /// Each line in the file should be the full path of an assembly (e.g. <c>C:\Users\Username\.nuget\packages\avalonia\11.0.4\ref\net6.0\Avalonia.Base.dll</c>)
+        /// </para>
+        /// <b>EXAMPLES</b><br/>
+        /// - <c>C:\Repos\RepoRoot\src\MyApp\Debug\net8.0\Avalonia\references</c><br/>
+        /// - <c>C:\Repos\RepoRoot\src\artifacts\obj\MyApp\debug\Avalonia\references</c><br/>
+        /// - <c>C:\Repos\RepoRoot\src\artifacts\obj\MyApp\debug_net8.0\Avalonia\references</c><br/>
+        /// See <see href="https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output#examples">Artifacts output layout &amp;gt; Examples</see> for more 'artifacts' path examples.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null or empty</exception>
         public AvaloniaCompilationAssemblyProvider(string path)
         {
             if (string.IsNullOrEmpty(path))
@@ -15,6 +30,11 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
             _path = path;
         }
 
+        /// <summary>
+        /// Reads the plain text file at <see cref="path"/> and returns the referenced assemblies' full paths.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="IOException">Failed to read the project's references file.</exception>
         public IEnumerable<string> GetAssemblies()
         {
             try

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,8 +17,22 @@ public class Metadata
         _namespaces.GetOrCreate(ns)[type.Name] = type;
         _inverseNamespace[type.FullName] = ns;
     }
+
+    /// <summary>
+    /// Add new metadata. Keys are added and existing keys are unchanged.
+    /// </summary>
+    public void AddMetadata(Metadata metadata)
+    {
+        foreach (var x in metadata._namespaces)
+            if (!_namespaces.ContainsKey(x.Key))
+                _namespaces.Add(x.Key, x.Value);
+        foreach (var x in metadata._inverseNamespace)
+            if (!_inverseNamespace.ContainsKey(x.Key))
+                _inverseNamespace.Add(x.Key, x.Value);
+    }
 }
 
+// todo: add property for permutation annotation. A MetadataType may be defined in multiple build contexts, but have different definitions.
 [DebuggerDisplay("{Name}")]
 public record MetadataType(string Name)
 {
@@ -50,7 +64,7 @@ public record MetadataType(string Name)
     public string? AssemblyQualifiedName { get; set; }
     public bool IsNullable { get; init; }
     public MetadataType? UnderlyingType { get; init; }
-    public IEnumerable<(MetadataType Type,string Name)> TemplateParts { get; internal set; } = 
+    public IEnumerable<(MetadataType Type, string Name)> TemplateParts { get; internal set; } =
         Array.Empty<(MetadataType Type, string Name)>();
     public bool IsAbstract { get; internal set; } = false;
 }

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -65,7 +65,11 @@ public static class MetadataConverter
         return false;
     }
 
-    public static MetadataType ConvertTypeInfomation(ITypeInformation type)
+    [Obsolete($"Method name was misspelled. Use {nameof(ConvertTypeInformation)} instead.")]
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public static MetadataType ConvertTypeInfomation(ITypeInformation type) => ConvertTypeInformation(type);
+
+    public static MetadataType ConvertTypeInformation(ITypeInformation type)
     {
         var mt = new MetadataType(type.Name)
         {
@@ -166,7 +170,7 @@ public static class MetadataConverter
 
             foreach (var type in asmTypes)
             {
-                var mt = types[type.AssemblyQualifiedName] = ConvertTypeInfomation(type);
+                var mt = types[type.AssemblyQualifiedName] = ConvertTypeInformation(type);
                 typeDefs[mt] = type;
                 metadata.AddType("clr-namespace:" + type.Namespace + ";assembly=" + asm.Name, mt);
                 string usingNamespace = $"using:{type.Namespace}";
@@ -212,7 +216,7 @@ public static class MetadataConverter
 
             type.TemplateParts = (typeDef?.TemplateParts ??
                 Array.Empty<(ITypeInformation, string)>())
-                .Select(item => (Type: ConvertTypeInfomation(item.Type), item.Name));
+                .Select(item => (Type: ConvertTypeInformation(item.Type), item.Name));
 
             while (typeDef != null)
             {

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -65,10 +65,6 @@ public static class MetadataConverter
         return false;
     }
 
-    [Obsolete($"Method name was misspelled. Use {nameof(ConvertTypeInformation)} instead.")]
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-    public static MetadataType ConvertTypeInfomation(ITypeInformation type) => ConvertTypeInformation(type);
-
     public static MetadataType ConvertTypeInformation(ITypeInformation type)
     {
         var mt = new MetadataType(type.Name)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,7 +10,7 @@ namespace Avalonia.Ide.CompletionEngine;
 
 public class CompletionEngine
 {
-    private record struct ElementCompletationInfo(string DisplayText, string InsertText, string? Suffix, int? RecommendedCursorOffset, bool TriggerCompletionAfterInsert);
+    private record struct ElementCompletionInfo(string DisplayText, string InsertText, string? Suffix, int? RecommendedCursorOffset, bool TriggerCompletionAfterInsert);
 
     public class MetadataHelper
     {
@@ -284,7 +284,7 @@ public class CompletionEngine
                     .Where(kvp => !kvp.Value.IsAbstract)
                     .Select(kvp =>
                         {
-                            var ci = GetElementCompletationInfo(kvp.Key, kvp.Value);
+                            var ci = GetElementCompletionInfo(kvp.Key, kvp.Value);
                             return new Completion(ci.DisplayText, ci.InsertText, CompletionKind.Class)
                             {
                                 RecommendedCursorOffset = ci.RecommendedCursorOffset,
@@ -405,7 +405,7 @@ public class CompletionEngine
                         if (state.AttributeName!.Equals("Selector"))
                         {
                             hintCompletions = false;
-                            if (ProcesssSelector(search.AsSpan(), state, completions, currentAssemblyName, fullText) is int delta)
+                            if (ProcessSelector(search.AsSpan(), state, completions, currentAssemblyName, fullText) is int delta)
                             {
                                 curStart = curStart + delta;
                             }
@@ -568,11 +568,11 @@ public class CompletionEngine
         };
     }
 
-    static ElementCompletationInfo GetElementCompletationInfo(string key,
+    static ElementCompletionInfo GetElementCompletionInfo(string key,
         MetadataType? type)
     {
         var xamlName = key;
-        var insretText = xamlName;
+        var insertText = xamlName;
         var recommendedCursorOffset = default(int?);
         var triggerCompletionAfterInsert = false;
         if (type is not null)
@@ -584,22 +584,22 @@ public class CompletionEngine
                     xamlName = xamlName.Substring(0, key.Length - 9 /* length of "extension" */);
                 }
             }
-            insretText = xamlName;
+            insertText = xamlName;
             if (type.IsGeneric)
             {
-                var targsStart = xamlName.IndexOf('`');
-                if (targsStart > -1)
+                var tArgsStart = xamlName.IndexOf('`');
+                if (tArgsStart > -1)
                 {
                     var xamlNameBuilder = new System.Text.StringBuilder();
                     var insertTextBuilder = new System.Text.StringBuilder();
-                    xamlNameBuilder.Append(xamlName, 0, targsStart);
-                    insertTextBuilder.Append(xamlName, 0, targsStart);
-                    var args = xamlName.Substring(targsStart + 1);
+                    xamlNameBuilder.Append(xamlName, 0, tArgsStart);
+                    insertTextBuilder.Append(xamlName, 0, tArgsStart);
+                    var args = xamlName.Substring(tArgsStart + 1);
                     if (int.TryParse(args
                         , System.Globalization.NumberStyles.Number
-                        , System.Globalization.CultureInfo.InvariantCulture, out var nargs))
+                        , System.Globalization.CultureInfo.InvariantCulture, out var nArgs))
                     {
-                        if (nargs == 1)
+                        if (nArgs == 1)
                         {
                             xamlNameBuilder.Append("<T>");
                             insertTextBuilder.Append(" x:TypeArguments=\"\"");
@@ -610,7 +610,7 @@ public class CompletionEngine
                             xamlNameBuilder.Append('<');
                             insertTextBuilder.Append(" x:TypeArguments=\"");
                             recommendedCursorOffset = insertTextBuilder.Length - 1;
-                            for (int i = 0; i < nargs; i++)
+                            for (int i = 0; i < nArgs; i++)
                             {
                                 xamlNameBuilder.Append('T');
                                 xamlNameBuilder.Append(i + 1);
@@ -621,13 +621,13 @@ public class CompletionEngine
                             insertTextBuilder[insertTextBuilder.Length - 1] = '"';
                         }
                         xamlName = xamlNameBuilder.ToString();
-                        insretText = insertTextBuilder.ToString();
+                        insertText = insertTextBuilder.ToString();
                         triggerCompletionAfterInsert = true;
                     }
                 }
             }
         }
-        return new (xamlName, insretText, default, recommendedCursorOffset, triggerCompletionAfterInsert);
+        return new(xamlName, insertText, default, recommendedCursorOffset, triggerCompletionAfterInsert);
     }
 
     private void ProcessStyleSetter(string setterPropertyName, XmlParser state, List<Completion> completions, string? currentAssemblyName)
@@ -822,7 +822,7 @@ public class CompletionEngine
         {
             if (i <= 1 && values[i] == "DataContext")
             {
-                //assume parent.datacontext is x:datatype so we have some intelisence
+                //assume parent.datacontext is x:datatype so we have some intellisense
                 type = state.FindParentAttributeValue("(x\\:)?DataType");
                 mdType = type is not null ? Helper.LookupType(type) : null;
             }
@@ -1016,12 +1016,14 @@ public class CompletionEngine
     public static CompletionKind GetCompletionKindForHintValues(MetadataType type)
         => type.IsEnum ? CompletionKind.Enum : CompletionKind.StaticProperty;
 
-
-    public int? ProcesssSelector(ReadOnlySpan<char> text, XmlParser state, List<Completion> completions, string? currentAssemblyName, string? fullText)
+    [Obsolete($"Method name was misspelled. Use {nameof(ProcessSelector)} instead.")]
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public int? ProcesssSelector(ReadOnlySpan<char> text, XmlParser state, List<Completion> completions, string? currentAssemblyName, string? fullText) => ProcessSelector(text, state, completions, currentAssemblyName, fullText);
+    public int? ProcessSelector(ReadOnlySpan<char> text, XmlParser state, List<Completion> completions, string? currentAssemblyName, string? fullText)
     {
-        int? parsered = default;
+        int? parsed = default;
         var parser = SelectorParser.Parse(text);
-        var previusStatment = parser.PreviousStatement;
+        var previousStatement = parser.PreviousStatement;
         switch (parser.Statement)
         {
             case SelectorStatement.Colon:
@@ -1030,7 +1032,7 @@ public class CompletionEngine
                     var fn = parser.FunctionName;
                     var tn = parser.TypeName;
                     var isEmptyTn = string.IsNullOrEmpty(tn);
-                    if (previusStatment <= SelectorStatement.Middle && isEmptyTn)
+                    if (previousStatement <= SelectorStatement.Middle && isEmptyTn)
                     {
                         completions.Add(new Completion(":is()", ":is(", CompletionKind.Selector | CompletionKind.Enum));
                     }
@@ -1064,7 +1066,7 @@ public class CompletionEngine
                                .Select(t => t.Value);
                         if (types?.Any() == true)
                         {
-                            parsered = text.Length - (parser.LastParsedPosition + 1);
+                            parsed = text.Length - (parser.LastParsedPosition + 1);
                             completions.AddRange(types.Select(v =>
                             {
                                 var name = GetXmlnsFullName(v);
@@ -1074,7 +1076,7 @@ public class CompletionEngine
                     }
                     if (completions.Count > 0)
                     {
-                        parsered = parser.LastParsedPosition ?? 0;
+                        parsed = parser.LastParsedPosition ?? 0;
                     }
                 }
                 break;
@@ -1105,7 +1107,7 @@ public class CompletionEngine
                                 }
                                 if (parts.Any())
                                 {
-                                    parsered = parser.LastParsedPosition ?? 0;
+                                    parsed = parser.LastParsedPosition ?? 0;
                                     var x = (parser.LastParsedPosition ?? 0) - parser.LastSegmentStartPosition - 1;
                                     if (string.IsNullOrEmpty(fullName) == false)
                                     {
@@ -1138,7 +1140,7 @@ public class CompletionEngine
                             {
                                 if (m.Success)
                                 {
-                                    parsered = (parser.LastParsedPosition ?? 0);
+                                    parsed = (parser.LastParsedPosition ?? 0);
                                     var name = m.Groups["AttribValue"].Value;
                                     completions.Add(new Completion(name, CompletionKind.Name | CompletionKind.Class));
                                 }
@@ -1170,7 +1172,7 @@ public class CompletionEngine
                                         .Where(t => t.IsMarkupExtension == false)
                                         .Where(t => t.IsAvaloniaObjectType || t.HasAttachedProperties);
                                     completions.AddRange(ft.Select(v => new Completion(v.Name, $"{ns}|{v.Name}", CompletionKind.Class | CompletionKind.TargetTypeClass)));
-                                    parsered = (parser.LastParsedPosition ?? 0) - (tn?.Length ?? 0);
+                                    parsed = (parser.LastParsedPosition ?? 0) - (tn?.Length ?? 0);
                                 }
                             }
                             else if (Helper.FilterTypes(typeFullName).Select(kvp => kvp.Value) is { } types)
@@ -1184,7 +1186,7 @@ public class CompletionEngine
                                     var name = GetXmlnsFullName(v);
                                     return new Completion(name, CompletionKind.Class | CompletionKind.TargetTypeClass);
                                 }));
-                                parsered = (parser.LastParsedPosition ?? 0) - (tn?.Length ?? 0);
+                                parsed = (parser.LastParsedPosition ?? 0) - (tn?.Length ?? 0);
                             }
                         }
                     }
@@ -1203,7 +1205,7 @@ public class CompletionEngine
                             );
                         if (selectorElementProperties?.Any() == true)
                         {
-                            parsered = (parser.LastParsedPosition ?? 0) - (propertyName?.Length ?? 0);
+                            parsed = (parser.LastParsedPosition ?? 0) - (propertyName?.Length ?? 0);
                             completions.AddRange(selectorElementProperties.Select(v => new Completion(v.Name, v.Name + "=", v.IsAttached ? CompletionKind.AttachedProperty : CompletionKind.Property)));
                         }
                     }
@@ -1226,7 +1228,7 @@ public class CompletionEngine
                             var lenType = lenPropertyName == 0 || typeFullName is null
                                 ? 0
                                 : typeFullName.Length + 1;
-                            parsered = (parser.LastParsedPosition ?? 0) - lenType - lenType + 1;
+                            parsed = (parser.LastParsedPosition ?? 0) - lenType - lenType + 1;
                             completions.AddRange(selectorElementProperties.Select(v => new Completion(v.Name, v.Name + ")", v.IsAttached ? CompletionKind.AttachedProperty : CompletionKind.Property)));
                         }
                     }
@@ -1237,7 +1239,7 @@ public class CompletionEngine
                              .Select(t => t.Value);
                         if (types?.Any() == true)
                         {
-                            parsered = (parser.LastParsedPosition ?? 0) + 1;
+                            parsed = (parser.LastParsedPosition ?? 0) + 1;
                             completions.AddRange(types.Select(v =>
                             {
                                 var name = GetXmlnsFullName(v);
@@ -1250,7 +1252,7 @@ public class CompletionEngine
             case SelectorStatement.Template:
                 {
                     completions.Add(new("/template/", "/template/", CompletionKind.Selector | CompletionKind.Enum));
-                    parsered = parser.LastParsedPosition;
+                    parsed = parser.LastParsedPosition;
                 }
                 break;
             case SelectorStatement.Traversal:
@@ -1258,7 +1260,7 @@ public class CompletionEngine
                 {
                     if (!parser.IsError)
                     {
-                        parsered = (parser.LastParsedPosition ?? 0);
+                        parsed = (parser.LastParsedPosition ?? 0);
                         // TODO: Crowling Selector operator from Attribute of the Selector
                         completions.Add(new Completion("^", CompletionKind.Selector | CompletionKind.Enum));
                         completions.Add(new Completion(":", CompletionKind.Selector | CompletionKind.Enum));
@@ -1306,7 +1308,7 @@ public class CompletionEngine
                                     .Where(v => v.StartsWith(value, StringComparison.OrdinalIgnoreCase));
                             }
                             completions.AddRange(values.Select(v => new Completion(v, kind)));
-                            parsered = parser.LastParsedPosition - (parser.Value?.Length ?? 0);
+                            parsed = parser.LastParsedPosition - (parser.Value?.Length ?? 0);
                         }
                     }
                 }
@@ -1318,7 +1320,7 @@ public class CompletionEngine
             default:
                 break;
         }
-        return parsered;
+        return parsed;
 
         string GetFullName(SelectorParser parser)
         {

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -1016,9 +1016,6 @@ public class CompletionEngine
     public static CompletionKind GetCompletionKindForHintValues(MetadataType type)
         => type.IsEnum ? CompletionKind.Enum : CompletionKind.StaticProperty;
 
-    [Obsolete($"Method name was misspelled. Use {nameof(ProcessSelector)} instead.")]
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-    public int? ProcesssSelector(ReadOnlySpan<char> text, XmlParser state, List<Completion> completions, string? currentAssemblyName, string? fullText) => ProcessSelector(text, state, completions, currentAssemblyName, fullText);
     public int? ProcessSelector(ReadOnlySpan<char> text, XmlParser state, List<Completion> completions, string? currentAssemblyName, string? fullText)
     {
         int? parsed = default;


### PR DESCRIPTION
# TODO
- [x] update references in AvaloniaVS extensions; Remove `Obsolete` symbols from AvaloniaVS.Shared
- [x] Investigate azure-pipelines build errors I'm unable to reproduce.
    `AvaloniaVS.Shared\Models\ProjectOutputInfo.cs(30,10): Error CS0246: The type or namespace name 'ObsoleteAttribute' could not be found (are you missing a using directive or an assembly reference?)`
    `AvaloniaVS.Shared\Models\ProjectOutputInfo.cs(30,10): Error CS0246: The type or namespace name 'Obsolete' could not be found (are you missing a using directive or an assembly reference?)`

# Features/Enhancements
- Added instance method `Avalonia.Ide.CompletionEngine.Metadata.AddMetadata(Metadata metadata)` to merge dictionaries from one Metadata into another. Keys are only added if they are not already present. Existing keys' values remain unchanged.
    This can be used to add metadata from various build contexts e.g. TargetFrameworks (build for multiple frameworks) and if-else compiler statements. Some TODO comments indicate potential improvements. How do we indicate which context a metadatum came from?

# Miscellaneous Changes
- Add xmldocs for `AvaloniaCompilationAssemblyProvider` `ctor` and `GetAssemblies()`. The API's usage misunderstood in AvaloniaVSCode's AvaloniaLanguageServer, causing builds to fail.
- Typos in `AvaloniaVS.Shared` and `Avalonia.Ide.CompletionEngine` corrected where understood
- Where affected by typos, Public API members' compatibility is maintained via aliases-like methods and properties ('=>' to correct definition). These aliases have been given the `Obsolete` annotation. Method aliases are aggressively in-lined.
 