### PR TITLE
Do not require the "SelectedTarget" to be an executable project

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -341,8 +341,7 @@ namespace AvaloniaVS.Views
 
                 bool IsValidTarget(ProjectInfo project)
                 {
-                    return project.IsExecutable &&
-                        project.References.Contains("Avalonia.DesignerSupport") &&
+                    return project.References.Contains("Avalonia.DesignerSupport") &&
                         (project.Project == _project || project.ProjectReferences.Contains(_project));
                 }
 


### PR DESCRIPTION
In some occasions the target project is actually not an executable project where `ProjectInfo.IsExecutable` return false. In such a case previewer runs into an error path "no executable found". 

This should fix: https://github.com/AvaloniaUI/AvaloniaVS/issues/472

It seems that the Rider integration also does not check for such a condition.