### PR TITLE
Fixed jagged lines on designer preview

### DIFF
--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml
@@ -122,7 +122,7 @@
             <Control/>
         </DockPanel>
 
-        <Grid x:Name="mainGrid">
+        <Grid x:Name="mainGrid" UseLayoutRounding="True">
             <Grid.RowDefinitions>
                 <RowDefinition x:Name="previewRow"/>
                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
Sometimes, on the previewer window, we can see jagged lines because the previewer's size has half pixels.

For example, before this change:

![image](https://github.com/user-attachments/assets/0956871d-c5d1-4b36-89d9-b51e3558b9d6)

After this change:

![image](https://github.com/user-attachments/assets/dfe6dfa2-d9e2-41be-a8b2-361d4e6156d8)
