### PR TITLE
Added option to swap editor and preview panes by default

### DIFF
--- a/AvaloniaVS.Shared/Services/AvaloniaVSSettings.cs
+++ b/AvaloniaVS.Shared/Services/AvaloniaVSSettings.cs
@@ -18,6 +18,7 @@ namespace AvaloniaVS.Services
         private const string SettingsKey = nameof(AvaloniaVSSettings);
         private readonly WritableSettingsStore _settings;
         private Orientation _designerSplitOrientation;
+        private bool _designerSplitSwapped = false;
         private AvaloniaDesignerView _designerView = AvaloniaDesignerView.Split;
         private LogEventLevel _minimumLogVerbosity = LogEventLevel.Information;
         private string _zoomLevel;
@@ -51,6 +52,19 @@ namespace AvaloniaVS.Services
                 if (_designerView != value)
                 {
                     _designerView = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool DesignerSplitSwapped
+        {
+            get => _designerSplitSwapped;
+            set
+            {
+                if (_designerSplitSwapped != value)
+                {
+                    _designerSplitSwapped = value;
                     RaisePropertyChanged();
                 }
             }
@@ -93,6 +107,10 @@ namespace AvaloniaVS.Services
                     SettingsKey,
                     nameof(DesignerSplitOrientation),
                     (int)Orientation.Vertical);
+                DesignerSplitSwapped = _settings.GetBoolean(
+                    SettingsKey,
+                    nameof(DesignerSplitSwapped),
+                    false);
                 DesignerView = (AvaloniaDesignerView)_settings.GetInt32(
                     SettingsKey,
                     nameof(DesignerView),
@@ -122,6 +140,7 @@ namespace AvaloniaVS.Services
                 }
 
                 _settings.SetInt32(SettingsKey, nameof(DesignerSplitOrientation), (int)DesignerSplitOrientation);
+                _settings.SetBoolean(SettingsKey, nameof(DesignerSplitSwapped), DesignerSplitSwapped);
                 _settings.SetInt32(SettingsKey, nameof(DesignerView), (int)DesignerView);
                 _settings.SetInt32(SettingsKey, nameof(MinimumLogVerbosity), (int)MinimumLogVerbosity);
                 _settings.SetString(SettingsKey, nameof(ZoomLevel), ZoomLevel);

--- a/AvaloniaVS.Shared/Services/IAvaloniaVSSettings.cs
+++ b/AvaloniaVS.Shared/Services/IAvaloniaVSSettings.cs
@@ -8,6 +8,7 @@ namespace AvaloniaVS.Services
     public interface IAvaloniaVSSettings : INotifyPropertyChanged
     {
         Orientation DesignerSplitOrientation { get; set; }
+        bool DesignerSplitSwapped { get; set; }
         AvaloniaDesignerView DesignerView { get; set; }
         LogEventLevel MinimumLogVerbosity { get; set; }
         string ZoomLevel { get; set; }

--- a/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
+++ b/AvaloniaVS.Shared/Views/AvaloniaDesigner.xaml.cs
@@ -189,6 +189,59 @@ namespace AvaloniaVS.Views
         }
 
         /// <summary>
+        /// Gets or sets whether the split view panes are swapped.
+        /// </summary>
+        public bool PreviewAndXamlPanesSwapped
+        {
+            get => SplitOrientation switch
+            {
+                Orientation.Horizontal => Grid.GetRow(editorHost) != 0,
+                Orientation.Vertical => Grid.GetColumn(editorHost) != 0,
+                _ => throw new NotSupportedException(),
+            };
+
+            set
+            {
+                if (value == PreviewAndXamlPanesSwapped)
+                {
+                    return;
+                }
+
+                switch (SplitOrientation)
+                {
+                    case Orientation.Horizontal:
+                        if (value)
+                        {
+                            Grid.SetRow(editorHost, 2);
+                            Grid.SetRow(previewer, 0);
+                        }
+                        else
+                        {
+                            Grid.SetRow(editorHost, 0);
+                            Grid.SetRow(previewer, 2);
+                        }
+                        break;
+
+                    case Orientation.Vertical:
+                        if (value)
+                        {
+                            Grid.SetColumn(editorHost, 2);
+                            Grid.SetColumn(previewer, 0);
+                        }
+                        else
+                        {
+                            Grid.SetColumn(editorHost, 0);
+                            Grid.SetColumn(previewer, 2);
+                        }
+                        break;
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the type of view to display.
         /// </summary>
         public AvaloniaDesignerView View
@@ -773,43 +826,7 @@ namespace AvaloniaVS.Views
             }
         }
 
-        private void SwapPreviewAndXamlPanes(object sender, RoutedEventArgs args)
-        {
-            switch (SplitOrientation)
-            {
-                case Orientation.Horizontal:
-                    var editorRow = Grid.GetRow(editorHost);
-
-                    if (editorRow == 0)
-                    {
-                        Grid.SetRow(editorHost, 2);
-                        Grid.SetRow(previewer, 0);
-                    }
-                    else
-                    {
-                        Grid.SetRow(editorHost, 0);
-                        Grid.SetRow(previewer, 2);
-                    }
-
-                    break;
-
-                case Orientation.Vertical:
-                    var editorCol = Grid.GetColumn(editorHost);
-
-                    if (editorCol == 0)
-                    {
-                        Grid.SetColumn(editorHost, 2);
-                        Grid.SetColumn(previewer, 0);
-                    }
-                    else
-                    {
-                        Grid.SetColumn(editorHost, 0);
-                        Grid.SetColumn(previewer, 2);
-                    }
-
-                    break;
-            }
-        }
+        private void SwapPreviewAndXamlPanes(object sender, RoutedEventArgs args) => PreviewAndXamlPanesSwapped = !PreviewAndXamlPanesSwapped;
 
         private void UpdateXaml(string xaml)
         {

--- a/AvaloniaVS.Shared/Views/EditorPane.cs
+++ b/AvaloniaVS.Shared/Views/EditorPane.cs
@@ -197,6 +197,7 @@ namespace AvaloniaVS.Shared.Views
             var xamlEditorView = _content;
             xamlEditorView.IsPaused = _isPaused;
             xamlEditorView.SplitOrientation = settings.DesignerSplitOrientation;
+            xamlEditorView.PreviewAndXamlPanesSwapped = settings.DesignerSplitSwapped;
             xamlEditorView.View = settings.DesignerView;
             xamlEditorView.ZoomLevel = settings.ZoomLevel;
             xamlEditorView.Start(_project, _textEditorHost.FileName, _textEditorHost.WpfTextViewHost);

--- a/AvaloniaVS.Shared/Views/OptionsView.xaml
+++ b/AvaloniaVS.Shared/Views/OptionsView.xaml
@@ -29,22 +29,26 @@
             <ColumnDefinition Width="180"/>
         </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Default Document View:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" />
+        <TextBlock Text="Default Document View:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" />
         <ComboBox Grid.Column="2" Grid.Row="0" VerticalAlignment="Center"
                   ItemsSource="{Binding Source={x:Type local:AvaloniaDesignerView}, Converter={StaticResource EnumValues}}"
                   SelectedItem="{Binding DesignerView, Mode=TwoWay}"/>
 
-        <TextBlock Text="Split Orientation:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" />
-        <ComboBox Grid.Column="2" Grid.Row="2" VerticalAlignment="Center"
-                  ItemsSource="{Binding Source={x:Type Orientation}, Converter={StaticResource EnumValues}}"
-                  SelectedItem="{Binding DesignerSplitOrientation, Mode=TwoWay}"/>
+        <TextBlock Text="Split Orientation:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" />
+        <StackPanel Grid.Column="2" Grid.Row="2">
+            <ComboBox VerticalAlignment="Center"
+                      ItemsSource="{Binding Source={x:Type Orientation}, Converter={StaticResource EnumValues}}"
+                      SelectedItem="{Binding DesignerSplitOrientation, Mode=TwoWay}"/>
+            <CheckBox VerticalAlignment="Center" Margin="0, 6, 0, 0"
+                      IsChecked="{Binding DesignerSplitSwapped, Mode=TwoWay}">Swapped</CheckBox>
+        </StackPanel>
       
-        <TextBlock Text="Default Zoom Level:" Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" />
+        <TextBlock Text="Default Zoom Level:" Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" />
         <ComboBox Grid.Column="2" Grid.Row="4" VerticalAlignment="Center"
                   ItemsSource="{x:Static a:ZoomLevels.Levels}"
                   SelectedItem="{Binding ZoomLevel, Mode=TwoWay}"/>
 
-        <TextBlock Text="Minimum Log Verbosity:" Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" />
+        <TextBlock Text="Minimum Log Verbosity:" Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" />
         <ComboBox Grid.Column="2" Grid.Row="6" VerticalAlignment="Center"
                   ItemsSource="{Binding Source={x:Type serilog:LogEventLevel}, Converter={StaticResource EnumValues}}"
                   SelectedItem="{Binding MinimumLogVerbosity, Mode=TwoWay}"/>


### PR DESCRIPTION
This adds an option to swap the preview and editor panes by default.

![image](https://github.com/user-attachments/assets/d00f0d7d-bfc8-45b2-bef2-6088efcdfda4)
