### PR TITLE
Fixing the sizing of the grid in the options view

### DIFF
--- a/AvaloniaVS.Shared/Views/OptionsView.xaml
+++ b/AvaloniaVS.Shared/Views/OptionsView.xaml
@@ -24,7 +24,7 @@
             <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="150" />
+            <ColumnDefinition MinWidth="150" Width="Auto" />
             <ColumnDefinition Width="20" />
             <ColumnDefinition Width="180"/>
         </Grid.ColumnDefinitions>


### PR DESCRIPTION
I run a larger than normal environment font size inside of Visual Studio as I do lots of presentations and want things easily visible. 

I have included before and after screen shots for clarity (grid lines enabled just for screenshots; they are not enabled in the change).

Before:
![image](https://github.com/user-attachments/assets/7019a9b7-5f69-4f33-81af-13a7530b62e3)

After:
![image](https://github.com/user-attachments/assets/44bcc36d-9c3a-4f66-aa10-81ddcf5b7af4)
