### PR TITLE
Added error details for exception stack trace

### DIFF
--- a/AvaloniaVS.Shared/Services/PreviewerProcess.cs
+++ b/AvaloniaVS.Shared/Services/PreviewerProcess.cs
@@ -463,6 +463,10 @@ namespace AvaloniaVS.Services
                         if (exception != null)
                         {
                             _log.Error(new XamlException(exception.Message, null, exception.LineNumber ?? 0, exception.LinePosition ?? 0), "UpdateXamlResult error");
+                            if (!string.IsNullOrWhiteSpace(update.Error))
+                            {
+                                _log.Error("UpdateXamlResult error details: {0}", update.Error);
+                            }
                         }
 
                         break;


### PR DESCRIPTION
This adds error details to the Avalonia Diagnostics log output for more information about designer exceptions. See also: https://github.com/AvaloniaUI/Avalonia/issues/16857

This may or may not be the desired approach. I'd be happy to make this better. For a starter PR, I decided to just log the output if it exists.