### PR TITLE
Add GetSourceProjectSafe

### DIFF
--- a/AvaloniaVS.Shared/Services/SolutionService.cs
+++ b/AvaloniaVS.Shared/Services/SolutionService.cs
@@ -187,7 +187,7 @@ namespace AvaloniaVS.Services
         {
             return project.References
                 .OfType<Reference>()
-                .Where(x => x.SourceProject != null)
+                .Where(x => GetSourceProjectSafe(x) != null)
                 .Select(x => x.SourceProject)
                 .ToList();
         }
@@ -196,8 +196,28 @@ namespace AvaloniaVS.Services
         {
             return project.References
                 .OfType<Reference>()
-                .Where(x => x.SourceProject == null)
+                .Where(x => GetSourceProjectSafe(x) == null)
                 .Select(x => x.Name).ToList();
+        }
+
+        /// <summary>
+        /// Returns the Reference's SourceProject. Returns null if any exceptions occur while 
+        /// attempting to access the Reference's SourceProject property.
+        /// </summary>
+        /// <remarks>
+        /// COM Errors or NotImplementedException may be thrown when attempting to access the
+        /// Reference's SourceProject property.
+        /// </remarks>
+        private static Project GetSourceProjectSafe(Reference reference)
+        {
+            try
+            {
+                return reference.SourceProject;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private static async Task<IReadOnlyList<ProjectOutputInfo>> GetOutputInfoAsync(Project project)


### PR DESCRIPTION
# Overview

Our solution contains a number of .csproj and .vcxproj files. A recent change to our own .vcxproj files suddenly caused the Avalonia design preview to fail when `Reference.SourceProject` was being accessed in `SolutionService.cs`. These failures showed up as either COM errors or as NotImplementedException (depending on the .vcxproj).

Despite the Avalonia design preview's failure, our solution would build correctly and we could correctly run our Avalonia desktop application. 

To resolve the issue, we implemented the changes in this PR and installed a locally built version of AvaloniaVS.VS2022.vsix. The Avalonia design preview is now working correctly in our solution with this fix.

# Testing

- Fix tested in VS2022 (v17.11.5) using a local build of the AvaloniaVS.VS2022.vsix.
- This fix restores the Avalonia design previewer's functionality in our solution.