### PR TITLE
Fix large TextBlock not wrapping

### DIFF
--- a/AvaloniaVS.Shared/Views/OptionsView.xaml
+++ b/AvaloniaVS.Shared/Views/OptionsView.xaml
@@ -12,53 +12,55 @@
     <UserControl.Resources>
         <conv:EnumValuesConverter x:Key="EnumValues"/>
     </UserControl.Resources>
-    
-    <Grid HorizontalAlignment="Left"  Margin="20 20">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="10" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="10" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="10" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="10" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-    </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition MinWidth="150" Width="Auto" />
-            <ColumnDefinition Width="20" />
-            <ColumnDefinition Width="180"/>
-        </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Default Document View:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" />
-        <ComboBox Grid.Column="2" Grid.Row="0" VerticalAlignment="Center"
+  <StackPanel Margin="20">
+    <Grid HorizontalAlignment="Left">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="10" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="10" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="10" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="10" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition MinWidth="150" Width="Auto" />
+        <ColumnDefinition Width="20" />
+        <ColumnDefinition Width="180"/>
+      </Grid.ColumnDefinitions>
+
+      <TextBlock Text="Default Document View:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" />
+      <ComboBox Grid.Column="2" Grid.Row="0" VerticalAlignment="Center"
                   ItemsSource="{Binding Source={x:Type local:AvaloniaDesignerView}, Converter={StaticResource EnumValues}}"
                   SelectedItem="{Binding DesignerView, Mode=TwoWay}"/>
 
-        <TextBlock Text="Split Orientation:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" />
-        <StackPanel Grid.Column="2" Grid.Row="2">
-            <ComboBox VerticalAlignment="Center"
+      <TextBlock Text="Split Orientation:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" />
+      <StackPanel Grid.Column="2" Grid.Row="2">
+        <ComboBox VerticalAlignment="Center"
                       ItemsSource="{Binding Source={x:Type Orientation}, Converter={StaticResource EnumValues}}"
                       SelectedItem="{Binding DesignerSplitOrientation, Mode=TwoWay}"/>
-            <CheckBox VerticalAlignment="Center" Margin="0, 6, 0, 0"
+        <CheckBox VerticalAlignment="Center" Margin="0, 6, 0, 0"
                       IsChecked="{Binding DesignerSplitSwapped, Mode=TwoWay}">Swapped</CheckBox>
-        </StackPanel>
-      
-        <TextBlock Text="Default Zoom Level:" Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" />
-        <ComboBox Grid.Column="2" Grid.Row="4" VerticalAlignment="Center"
+      </StackPanel>
+
+      <TextBlock Text="Default Zoom Level:" Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" />
+      <ComboBox Grid.Column="2" Grid.Row="4" VerticalAlignment="Center"
                   ItemsSource="{x:Static a:ZoomLevels.Levels}"
                   SelectedItem="{Binding ZoomLevel, Mode=TwoWay}"/>
 
-        <TextBlock Text="Minimum Log Verbosity:" Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" />
-        <ComboBox Grid.Column="2" Grid.Row="6" VerticalAlignment="Center"
+      <TextBlock Text="Minimum Log Verbosity:" Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" />
+      <ComboBox Grid.Column="2" Grid.Row="6" VerticalAlignment="Center"
                   ItemsSource="{Binding Source={x:Type serilog:LogEventLevel}, Converter={StaticResource EnumValues}}"
                   SelectedItem="{Binding MinimumLogVerbosity, Mode=TwoWay}"/>
 
-    <TextBlock Text="Anonymouse Usage Analytis:" Grid.Column="0" Grid.Row="8" VerticalAlignment="Top" />
-    <CheckBox VerticalAlignment="Center" Grid.Column="2" Grid.Row="8"
+      <TextBlock Text="Anonymous Usage Analytics:" Grid.Column="0" Grid.Row="8" VerticalAlignment="Top" />
+      <CheckBox VerticalAlignment="Center" Grid.Column="2" Grid.Row="8"
            IsChecked="{Binding UsageTracking, Mode=TwoWay}">Enabled</CheckBox>
-    <TextBlock Text="Support the improvement of the Avalonia Visual Studio extension by sharing anonymous usage data. No PII, source code, or any sensitive material is ever collected." TextWrapping="Wrap" FontSize="13" Grid.ColumnSpan="3" Grid.Row="9" VerticalAlignment="Center" />
-  </Grid>
+    </Grid>
+
+    <TextBlock Text="Support the improvement of the Avalonia Visual Studio extension by sharing anonymous usage data. No PII, source code, or any sensitive material is ever collected." TextWrapping="Wrap" FontSize="13" />
+  </StackPanel>
 </UserControl>


### PR DESCRIPTION
Fixes #514

v11.9 introduced the anonymous logging of analytics. The Options pane included a long text description below the checkbox for disabling this. Due to how the text was added (within a grid), it caused all the content to expand beyond the bounds of the dialog, rather than have the text wrap.

The sizing problem can be seen in the images in the [original issue](https://github.com/AvaloniaUI/AvaloniaVS/issues/514)

Addressing this as a usability and accessibility issue, as without a screen wide enough to resize the dialog, the text is unreadable and may not be able to access the settings.


- This change resets the original grid sizing (including adjusting for text scaling) and positions the wrapping text beneath it. As seen below.
 
![avalonia-options-resizing](https://github.com/user-attachments/assets/9c4630f8-6d74-4be2-b282-136eaca8e7d1)


- Also corrects the spelling of the new label
from "Anonymous**e** Usage Analytis"
to  "Anonymous Usage Analyti**c**s"
(removed an "e" and added a "c")