### PR TITLE
Filtering autocompletion properties with Contains instead of StartsWith

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -81,7 +81,7 @@ public class CompletionEngine
             prefix ??= "";
 
             var e = _types
-                .Where(t => t.Value.IsXamlDirective == xamlDirectiveOnly && t.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .Where(t => t.Value.IsXamlDirective == xamlDirectiveOnly && t.Key.Contains(prefix, StringComparison.OrdinalIgnoreCase))
                 .Where(x => !x.Key.Equals("ControlTemplateResult") && !x.Key.Equals("DataTemplateExtensions"));
             if (withAttachedPropertiesOrEventsOnly)
                 e = e.Where(t => t.Value.HasAttachedProperties || t.Value.HasAttachedEvents);
@@ -164,7 +164,7 @@ public class CompletionEngine
             if (t == null)
                 return Array.Empty<string>();
 
-            return t.Events.Where(n => n.IsAttached == attached && n.Name.StartsWith(propName, StringComparison.OrdinalIgnoreCase)).Select(n => n.Name);
+            return t.Events.Where(n => n.IsAttached == attached && n.Name.Contains(propName, StringComparison.OrdinalIgnoreCase)).Select(n => n.Name);
         }
 
         public MetadataProperty? LookupProperty(string? typeName, string? propName)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Completion/CompletionEngine.cs
@@ -142,9 +142,9 @@ public class CompletionEngine
             propName ??= "";
             if (t == null)
                 return Array.Empty<MetadataProperty>();
-
-            var e = t.Properties.Where(p => p.Name.StartsWith(propName, StringComparison.OrdinalIgnoreCase) && (hasSetter ? p.HasSetter : p.HasGetter));
-
+            
+            var e = t.Properties.Where(p => p.Name.Contains(propName, StringComparison.OrdinalIgnoreCase) && (hasSetter ? p.HasSetter : p.HasGetter));
+            
             if (attached.HasValue)
                 e = e.Where(p => p.IsAttached == attached);
             if (staticGetter)

--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Utils.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Utils.cs
@@ -117,4 +117,14 @@ internal static class Utils
         }
         return default;
     }
+
+    public static bool Contains(this string source, string value, StringComparison comparisonType)
+    {
+        return Contains(source.AsSpan(), value.AsSpan(), comparisonType);
+    }
+
+    public static bool Contains(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+    {
+        return span.IndexOf(value, comparisonType) >= 0;
+    }
 }


### PR DESCRIPTION
Previously filtering of the completion was done with StartsWith. This is not problem if you know what do you want find, but if you are a beginner, you may not know whether an element has a property or not and you want to find it.
Before:
![Before](https://github.com/user-attachments/assets/f50477a0-1cbb-4d8b-8b50-79e318f80ee8)

After:
![After](https://github.com/user-attachments/assets/935e1b28-a18f-400e-98fc-1e08e7560ef5)
