### PR TITLE
Expose some members for document outlines

### DIFF
--- a/CompletionEngine/Avalonia.Ide.CompletionEngine/Parsing/XmlParser.cs
+++ b/CompletionEngine/Avalonia.Ide.CompletionEngine/Parsing/XmlParser.cs
@@ -64,6 +64,9 @@ public class XmlParser
 
     public bool IsInClosingTag => _isClosingTag;
 
+    // Minimal public exposure for external outline enumeration
+    public int ElementNameStart => _elementNameStart;
+
     public XmlParser(ReadOnlyMemory<char> data, int start = 0)
     {
         _containingTagStart = new Stack<int>();
@@ -94,7 +97,7 @@ public class XmlParser
         return true;
     }
 
-    private bool ParseChar()
+    public bool ParseChar()
     {
         if (_parserPos >= _data.Length)
         {


### PR DESCRIPTION
To support document outlines in the language server, a few private members of `XmlParser` need to be made public.